### PR TITLE
Refresh lifecycle timeline UI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,11 @@
 {
-  // IntelliSense を使用して利用可能な属性を学べます。
-  // 既存の属性の説明をホバーして表示します。
-  // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
       "type": "chrome",
       "request": "launch",
       "name": "ローカルアプリを起動",
-      "url": "http://127.0.0.1:5501/login.html",
+      "url": "http://127.0.0.1:5501/list.html",
       "webRoot": "${workspaceFolder}",
       "preLaunchTask": "local-server-5501"
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,14 +12,21 @@
       "isBackground": true,
       "problemMatcher": {
         "owner": "local-server",
-        "pattern": {
-          "regexp": ".*"
-        },
+        "pattern": [
+          {
+            "regexp": ".+"
+          }
+        ],
         "background": {
           "activeOnStart": true,
           "beginsPattern": ".*",
-          "endsPattern": "Serving HTTP on.*"
+          "endsPattern": "Serving HTTP on .* port 5501"
         }
+      },
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated",
+        "clear": true
       }
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,11 +12,11 @@
       "isBackground": true,
       "problemMatcher": {
         "owner": "local-server",
-        "pattern": [
-          {
-            "regexp": ".+"
-          }
-        ],
+        "pattern": {
+          "regexp": "^(LOCAL_SERVER_NEVER_MATCHES)$",
+          "file": 1,
+          "message": 1
+        },
         "background": {
           "activeOnStart": true,
           "beginsPattern": ".*",

--- a/form.html
+++ b/form.html
@@ -19,9 +19,7 @@
 
       <section id="form-panel" class="panel" aria-labelledby="form-title">
         <h2 id="form-title">入力フォーム</h2>
-        <p id="auth-status" class="form-mode"></p>
         <p id="auth-error" class="form-error"></p>
-        <p id="form-mode" class="form-mode">現在: 新規登録</p>
         <form id="item-form" novalidate>
           <input id="item-id" type="hidden" />
 
@@ -46,6 +44,17 @@
               <button id="add-cost-button" class="ghost-button small-button" type="button">追加</button>
             </div>
             <div id="additional-cost-list" class="additional-cost-list"></div>
+          </section>
+
+          <section class="calculation-result" aria-label="計算結果">
+            <div>
+              <span>合計</span>
+              <strong id="calculation-total">¥0</strong>
+            </div>
+            <div>
+              <span>月額コスト</span>
+              <strong id="calculation-monthly-cost">¥0 /月</strong>
+            </div>
           </section>
 
           <p id="form-error" class="form-error"></p>

--- a/form.html
+++ b/form.html
@@ -58,6 +58,10 @@
           </section>
 
           <p id="form-error" class="form-error"></p>
+          <label class="checkbox-field" for="hide-from-timeline">
+            <input id="hide-from-timeline" type="checkbox" />
+            <span>帯を表示しない</span>
+          </label>
           <div class="form-actions">
             <button id="submit-button" class="primary-button" type="submit">登録する</button>
             <button id="cancel-button" class="ghost-button" type="button" hidden>編集をキャンセル</button>

--- a/hidden.html
+++ b/hidden.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>非表示商品 | 耐久消費財管理</title>
+    <meta name="theme-color" content="#1f2933" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="icon" href="icons/icon-192.png" type="image/png" />
+    <link rel="apple-touch-icon" href="icons/icon-192.png" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body class="dashboard-body" data-timeline-mode="hidden">
+    <main class="app dashboard-app">
+      <header class="app-header dashboard-header">
+        <div class="dashboard-title">
+          <h1>非表示商品</h1>
+        </div>
+        <div class="dashboard-actions">
+          <button id="back-button" type="button" class="ghost-button" onclick="location.href='list.html'">戻る</button>
+        </div>
+      </header>
+
+      <section class="panel timeline-panel" aria-labelledby="list-title">
+        <h2 id="list-title">ライフサイクル年表</h2>
+        <p id="auth-error" class="form-error"></p>
+        <div id="item-list" class="timeline-shell"></div>
+      </section>
+    </main>
+
+    <dialog id="item-name-dialog" class="item-name-dialog">
+      <article class="item-name-dialog-card">
+        <h2 id="dialog-item-name"></h2>
+        <p id="dialog-item-meta" class="dialog-item-meta"></p>
+        <div class="dialog-actions">
+          <button id="dialog-edit-button" type="button" class="primary-button">編集</button>
+          <button id="dialog-delete-button" type="button" class="danger-button">削除</button>
+          <button id="dialog-close-button" type="button" class="ghost-button">閉じる</button>
+        </div>
+      </article>
+    </dialog>
+    <script type="module" src="js/list.js"></script>
+  </body>
+</html>

--- a/js/common.js
+++ b/js/common.js
@@ -228,6 +228,7 @@ export async function loadItems(uid) {
       purchasePrice: Number(data.purchasePrice ?? 0),
       yearsOfUse: Number(data.yearsOfUse ?? 0),
       endOfUseDate: data.endOfUseDate ?? "",
+      hideFromTimeline: Boolean(data.hideFromTimeline),
       additionalCosts: normalizeAdditionalCosts(data.additionalCosts),
       createdAt: data.createdAt ?? null,
       updatedAt: data.updatedAt ?? null,
@@ -255,6 +256,7 @@ export async function loadItem(uid, itemId) {
     purchasePrice: Number(data.purchasePrice ?? 0),
     yearsOfUse: Number(data.yearsOfUse ?? 0),
     endOfUseDate: data.endOfUseDate ?? "",
+    hideFromTimeline: Boolean(data.hideFromTimeline),
     additionalCosts: normalizeAdditionalCosts(data.additionalCosts),
   };
 }
@@ -268,6 +270,7 @@ export async function saveItem(uid, item) {
     purchasePrice: item.purchasePrice,
     yearsOfUse: item.yearsOfUse,
     endOfUseDate: item.endOfUseDate,
+    hideFromTimeline: Boolean(item.hideFromTimeline),
     additionalCosts: normalizeAdditionalCosts(item.additionalCosts),
     updatedAt: serverTimestamp(),
   };

--- a/js/common.js
+++ b/js/common.js
@@ -35,6 +35,9 @@ export const ITEMS_COLLECTION = "durableGoodsItems";
 export const DEFAULT_CATEGORY = "other";
 export const CATEGORY_OPTIONS = [
   { value: "home_appliance", label: "家電" },
+  { value: "tv", label: "テレビ" },
+  { value: "cooking_appliance", label: "調理家電" },
+  { value: "washing_machine", label: "洗濯機" },
   { value: "car", label: "自動車" },
   { value: "smartphone", label: "スマホ" },
   { value: "pc", label: "パソコン" },

--- a/js/common.js
+++ b/js/common.js
@@ -33,6 +33,8 @@ export const db = getFirestore(app);
 export const auth = getAuth(app);
 export const ITEMS_COLLECTION = "durableGoodsItems";
 export const DEFAULT_CATEGORY = "other";
+export const PC_MODEL_PREFIX = "[pcManagement]";
+export const PC_PART_MEMO_PREFIX = "[pcPart]";
 export const CATEGORY_OPTIONS = [
   { value: "home_appliance", label: "家電" },
   { value: "tv", label: "テレビ" },
@@ -46,11 +48,19 @@ export const CATEGORY_OPTIONS = [
 
 export function registerServiceWorker() {
   if (!("serviceWorker" in navigator)) return;
+  let isReloadingForUpdate = false;
+  navigator.serviceWorker.addEventListener("controllerchange", () => {
+    if (isReloadingForUpdate) return;
+    isReloadingForUpdate = true;
+    window.location.reload();
+  });
+
   window.addEventListener("load", async () => {
     try {
-      await navigator.serviceWorker.register(new URL("../service-worker.js", import.meta.url), {
+      const registration = await navigator.serviceWorker.register(new URL("../service-worker.js", import.meta.url), {
         scope: "../",
       });
+      await registration.update();
     } catch (_error) {
       // SW registration failure is non-fatal.
     }
@@ -91,6 +101,45 @@ export function normalizeCategory(value) {
 export function getCategoryLabel(value) {
   const normalizedValue = normalizeCategory(value);
   return CATEGORY_OPTIONS.find((category) => category.value === normalizedValue)?.label ?? "その他";
+}
+
+export function decodePcPartMemo(value) {
+  return parsePrefixedJson(value, PC_PART_MEMO_PREFIX);
+}
+
+export function decodePcManagementModel(value) {
+  return parsePrefixedJson(value, PC_MODEL_PREFIX);
+}
+
+function parsePrefixedJson(value, prefix) {
+  const text = String(value ?? "");
+  if (!text.startsWith(prefix)) return null;
+  const jsonText = text.slice(prefix.length);
+  try {
+    return JSON.parse(jsonText);
+  } catch (_error) {
+    try {
+      return JSON.parse(jsonText.replace(/("[^"]+"\s*:\s*"[^"]*")\.(\s*"[^"]+"\s*:)/g, "$1,$2"));
+    } catch (_fallbackError) {
+      return null;
+    }
+  }
+}
+
+export function pcPartMemoDisplayText(value) {
+  const decoded = decodePcPartMemo(value);
+  if (!decoded) return String(value ?? "");
+  const partName = String(decoded.partName ?? "").trim();
+  const memo = String(decoded.memo ?? "").trim();
+  if (partName && memo) return `${partName} / ${memo}`;
+  return partName || memo || "PCパーツ";
+}
+
+export function pcManagementModelDisplayText(value) {
+  const decoded = decodePcManagementModel(value);
+  if (!decoded) return String(value ?? "");
+  const itemName = String(decoded.itemName ?? "").trim();
+  return itemName ? `PC管理データ（${itemName}）` : "PC管理データ";
 }
 
 export function calculateMonthlyCost(item) {

--- a/js/common.js
+++ b/js/common.js
@@ -36,15 +36,23 @@ export const DEFAULT_CATEGORY = "other";
 export const PC_MODEL_PREFIX = "[pcManagement]";
 export const PC_PART_MEMO_PREFIX = "[pcPart]";
 export const CATEGORY_OPTIONS = [
-  { value: "home_appliance", label: "家電" },
-  { value: "tv", label: "テレビ" },
-  { value: "cooking_appliance", label: "調理家電" },
-  { value: "washing_machine", label: "洗濯機" },
-  { value: "car", label: "自動車" },
+  { value: "information_device", label: "情報機器" },
   { value: "smartphone", label: "スマホ" },
-  { value: "pc", label: "パソコン" },
+  { value: "audio_visual", label: "映像・音響" },
+  { value: "air_conditioning", label: "空調家電" },
+  { value: "living_appliance", label: "生活家電" },
+  { value: "cooking_appliance", label: "調理家電" },
+  { value: "beauty_health", label: "美容・健康" },
   { value: "other", label: "その他" },
 ];
+
+const LEGACY_CATEGORY_MAP = {
+  home_appliance: "living_appliance",
+  tv: "audio_visual",
+  washing_machine: "living_appliance",
+  car: "other",
+  pc: "information_device",
+};
 
 export function registerServiceWorker() {
   if (!("serviceWorker" in navigator)) return;
@@ -93,9 +101,8 @@ export function formatCurrency(value) {
 
 export function normalizeCategory(value) {
   const normalizedValue = String(value ?? "");
-  return CATEGORY_OPTIONS.some((category) => category.value === normalizedValue)
-    ? normalizedValue
-    : DEFAULT_CATEGORY;
+  const mappedValue = LEGACY_CATEGORY_MAP[normalizedValue] ?? normalizedValue;
+  return CATEGORY_OPTIONS.some((category) => category.value === mappedValue) ? mappedValue : DEFAULT_CATEGORY;
 }
 
 export function getCategoryLabel(value) {
@@ -109,6 +116,10 @@ export function decodePcPartMemo(value) {
 
 export function decodePcManagementModel(value) {
   return parsePrefixedJson(value, PC_MODEL_PREFIX);
+}
+
+export function isPcManagementItem(item) {
+  return item?.sourceType === "pcManagement" || Boolean(decodePcManagementModel(item?.model));
 }
 
 function parsePrefixedJson(value, prefix) {
@@ -212,6 +223,7 @@ export async function loadItems(uid) {
       name: data.name ?? "",
       model: data.model ?? "",
       category: normalizeCategory(data.category),
+      sourceType: data.sourceType ?? "",
       purchaseDate: data.purchaseDate ?? "",
       purchasePrice: Number(data.purchasePrice ?? 0),
       yearsOfUse: Number(data.yearsOfUse ?? 0),
@@ -238,6 +250,7 @@ export async function loadItem(uid, itemId) {
     name: data.name ?? "",
     model: data.model ?? "",
     category: normalizeCategory(data.category),
+    sourceType: data.sourceType ?? "",
     purchaseDate: data.purchaseDate ?? "",
     purchasePrice: Number(data.purchasePrice ?? 0),
     yearsOfUse: Number(data.yearsOfUse ?? 0),

--- a/js/form.js
+++ b/js/form.js
@@ -8,7 +8,11 @@ import {
   normalizeCategory,
   CATEGORY_OPTIONS,
   DEFAULT_CATEGORY,
+  decodePcManagementModel,
+  decodePcPartMemo,
   firebaseErrorMessage,
+  pcManagementModelDisplayText,
+  pcPartMemoDisplayText,
   registerServiceWorker,
 } from "./common.js";
 
@@ -76,8 +80,13 @@ function createAdditionalCostRow(cost = {}) {
   memoInput.type = "text";
   memoInput.autocomplete = "off";
   memoInput.placeholder = "メモ";
-  memoInput.value = cost.memo ?? "";
+  memoInput.value = pcPartMemoDisplayText(cost.memo);
   memoInput.setAttribute("aria-label", "追加費用のメモ");
+  if (decodePcPartMemo(cost.memo)) {
+    row.dataset.encodedMemo = cost.memo;
+    memoInput.readOnly = true;
+    memoInput.title = "PC管理のパーツ情報です。編集はパソコン管理画面で行ってください。";
+  }
 
   const deleteButton = document.createElement("button");
   deleteButton.className = "danger-button small-button additional-cost-delete";
@@ -118,7 +127,7 @@ function collectAdditionalCosts() {
     if (!(amountInput instanceof HTMLInputElement) || !(memoInput instanceof HTMLInputElement)) continue;
 
     const rawAmount = amountInput.value.trim();
-    const memo = memoInput.value.trim();
+    const memo = row.dataset.encodedMemo || memoInput.value.trim();
     const createdAt = Number(row.dataset.createdAt);
     if (!rawAmount && !memo) continue;
 
@@ -135,7 +144,17 @@ function collectAdditionalCosts() {
 function fillForm(item) {
   idInput.value = item.id;
   nameInput.value = item.name;
-  modelInput.value = item.model;
+  if (decodePcManagementModel(item.model)) {
+    modelInput.value = pcManagementModelDisplayText(item.model);
+    modelInput.dataset.encodedModel = item.model;
+    modelInput.readOnly = true;
+    modelInput.title = "PC管理の内部データです。編集はパソコン管理画面で行ってください。";
+  } else {
+    modelInput.value = item.model;
+    delete modelInput.dataset.encodedModel;
+    modelInput.readOnly = false;
+    modelInput.title = "";
+  }
   categoryInput.value = normalizeCategory(item.category);
   purchaseDateInput.value = item.purchaseDate;
   purchasePriceInput.value = item.purchasePrice;
@@ -183,7 +202,7 @@ form.addEventListener("submit", async (event) => {
     id: idInput.value || createId(),
     isUpdate: Boolean(state.editingId),
     name: nameInput.value.trim(),
-    model: modelInput.value.trim(),
+    model: modelInput.dataset.encodedModel || modelInput.value.trim(),
     category: categoryInput.value,
     purchaseDate: purchaseDateInput.value,
     purchasePrice: Number(purchasePriceInput.value),

--- a/js/form.js
+++ b/js/form.js
@@ -33,6 +33,7 @@ const purchaseDateInput = document.getElementById("purchase-date");
 const purchasePriceInput = document.getElementById("purchase-price");
 const yearsOfUseInput = document.getElementById("years-of-use");
 const endOfUseDateInput = document.getElementById("end-of-use-date");
+const hideFromTimelineInput = document.getElementById("hide-from-timeline");
 const addCostButton = document.getElementById("add-cost-button");
 const additionalCostList = document.getElementById("additional-cost-list");
 const calculationTotal = document.getElementById("calculation-total");
@@ -191,6 +192,7 @@ function fillForm(item) {
   purchasePriceInput.value = item.purchasePrice;
   yearsOfUseInput.value = item.yearsOfUse;
   endOfUseDateInput.value = item.endOfUseDate;
+  hideFromTimelineInput.checked = Boolean(item.hideFromTimeline);
   updateEndedUseStyle();
   renderAdditionalCosts(item.additionalCosts);
 }
@@ -248,6 +250,7 @@ form.addEventListener("submit", async (event) => {
     purchasePrice: Number(purchasePriceInput.value),
     yearsOfUse: Number(yearsOfUseInput.value),
     endOfUseDate: endOfUseDateInput.value,
+    hideFromTimeline: hideFromTimelineInput.checked,
     additionalCosts: collectAdditionalCosts(),
   };
   const validation = validateItem(item);

--- a/js/form.js
+++ b/js/form.js
@@ -11,17 +11,16 @@ import {
   decodePcManagementModel,
   decodePcPartMemo,
   firebaseErrorMessage,
+  formatCurrency,
   pcManagementModelDisplayText,
   pcPartMemoDisplayText,
   registerServiceWorker,
 } from "./common.js";
 
-const authStatus = document.getElementById("auth-status");
 const authError = document.getElementById("auth-error");
 const toListButton = document.getElementById("to-list-button");
 const form = document.getElementById("item-form");
 const formPanel = document.getElementById("form-panel");
-const formMode = document.getElementById("form-mode");
 const formError = document.getElementById("form-error");
 const submitButton = document.getElementById("submit-button");
 const cancelButton = document.getElementById("cancel-button");
@@ -36,6 +35,8 @@ const yearsOfUseInput = document.getElementById("years-of-use");
 const endOfUseDateInput = document.getElementById("end-of-use-date");
 const addCostButton = document.getElementById("add-cost-button");
 const additionalCostList = document.getElementById("additional-cost-list");
+const calculationTotal = document.getElementById("calculation-total");
+const calculationMonthlyCost = document.getElementById("calculation-monthly-cost");
 
 const state = {
   uid: null,
@@ -55,6 +56,35 @@ function populateCategorySelect() {
 
 function updateEndedUseStyle() {
   formPanel.classList.toggle("ended-use", Boolean(endOfUseDateInput.value));
+}
+
+function formatMonthlyCost(value) {
+  return `${formatCurrency(value)} /月`;
+}
+
+function parseCurrencyInputValue(value) {
+  const normalizedValue = String(value ?? "").replaceAll(",", "").trim();
+  const amount = Number(normalizedValue);
+  return Number.isFinite(amount) && amount > 0 ? amount : 0;
+}
+
+function calculateAdditionalCostInputTotal() {
+  const rows = additionalCostList.querySelectorAll(".additional-cost-row");
+  return [...rows].reduce((total, row) => {
+    const amountInput = row.querySelector(".additional-cost-amount");
+    if (!(amountInput instanceof HTMLInputElement)) return total;
+    return total + parseCurrencyInputValue(amountInput.value);
+  }, 0);
+}
+
+function updateCalculationResult() {
+  const purchasePrice = parseCurrencyInputValue(purchasePriceInput.value);
+  const yearsOfUse = Number(yearsOfUseInput.value);
+  const total = purchasePrice + calculateAdditionalCostInputTotal();
+  const monthlyCost = Number.isFinite(yearsOfUse) && yearsOfUse > 0 ? total / (yearsOfUse * 12) : 0;
+
+  calculationTotal.textContent = formatCurrency(total);
+  calculationMonthlyCost.textContent = formatMonthlyCost(monthlyCost);
 }
 
 function createAdditionalCostRow(cost = {}) {
@@ -116,6 +146,7 @@ function renderAdditionalCosts(costs) {
   if (additionalCostList.children.length === 0) {
     additionalCostList.appendChild(createAdditionalCostRow({ createdAt: Date.now() }));
   }
+  updateCalculationResult();
 }
 
 function collectAdditionalCosts() {
@@ -178,6 +209,7 @@ addCostButton.addEventListener("click", () => {
   const row = createAdditionalCostRow({ createdAt: Date.now() });
   additionalCostList.prepend(row);
   row.querySelector(".additional-cost-amount")?.focus();
+  updateCalculationResult();
 });
 
 additionalCostList.addEventListener("click", (event) => {
@@ -188,7 +220,15 @@ additionalCostList.addEventListener("click", (event) => {
   if (additionalCostList.children.length === 0) {
     additionalCostList.appendChild(createAdditionalCostRow({ createdAt: Date.now() }));
   }
+  updateCalculationResult();
 });
+
+form.addEventListener("input", updateCalculationResult);
+form.addEventListener("change", updateCalculationResult);
+purchasePriceInput.addEventListener("input", updateCalculationResult);
+yearsOfUseInput.addEventListener("input", updateCalculationResult);
+additionalCostList.addEventListener("input", updateCalculationResult);
+additionalCostList.addEventListener("change", updateCalculationResult);
 
 endOfUseDateInput.addEventListener("input", () => {
   updateEndedUseStyle();
@@ -232,10 +272,8 @@ onAuthChanged(async (user) => {
     return;
   }
   state.uid = user.uid;
-  authStatus.textContent = `状態: ログイン中 (${user.email ?? "メール未設定"})`;
 
   if (!state.editingId) {
-    formMode.textContent = "現在: 新規登録";
     submitButton.textContent = "登録する";
     cancelButton.hidden = true;
     updateEndedUseStyle();
@@ -243,7 +281,6 @@ onAuthChanged(async (user) => {
     return;
   }
 
-  formMode.textContent = "現在: 編集中";
   submitButton.textContent = "更新する";
   cancelButton.hidden = false;
 

--- a/js/list.js
+++ b/js/list.js
@@ -3,6 +3,7 @@ import {
   logout,
   loadItems,
   removeItem,
+  calculateMonthlyCost,
   calculateMonthlyCostWithAdditionalCosts,
   formatCurrency,
   CATEGORY_OPTIONS,
@@ -37,6 +38,7 @@ const DESKTOP_YEAR_WIDTH = 168;
 const DESKTOP_LABEL_WIDTH = 230;
 const MOBILE_YEAR_WIDTH = 28;
 const MOBILE_LABEL_WIDTH = 72;
+const TIMELINE_MODE = document.body.dataset.timelineMode || "visible";
 
 const state = {
   uid: null,
@@ -195,10 +197,16 @@ function lifecycleStatus(item) {
   return "normal";
 }
 
+function timelineMonthlyCost(item) {
+  return isPcManagementItem(item) ? calculateMonthlyCost(item) : calculateMonthlyCostWithAdditionalCosts(item);
+}
+
 function summarizeItems(items) {
+  if (!summaryMonthlyCost || !summaryPurchaseTotal || !summaryItemCount) return;
+
   const activeItems = items.filter((item) => !item.endOfUseDate);
   const monthlyCostTotal = activeItems.reduce(
-    (total, item) => total + calculateMonthlyCostWithAdditionalCosts(item),
+    (total, item) => total + timelineMonthlyCost(item),
     0
   );
   const purchaseTotal = activeItems.reduce((total, item) => total + Number(item.purchasePrice || 0), 0);
@@ -211,10 +219,15 @@ function summarizeItems(items) {
 function renderEmptyTimeline() {
   itemList.innerHTML = "";
   const empty = createElement("div", "timeline-empty");
+  const message =
+    TIMELINE_MODE === "hidden"
+      ? "帯を表示しない商品はありません。"
+      : "家電を登録すると、購入日から耐用年数までのライフサイクル帯を表示します。";
   empty.innerHTML = `
     <strong>登録データがありません</strong>
-    <span>家電を登録すると、購入日から耐用年数までのライフサイクル帯を表示します。</span>
+    <span></span>
   `;
+  empty.querySelector("span").textContent = message;
   itemList.appendChild(empty);
 }
 
@@ -331,7 +344,7 @@ function renderTimeline(items) {
     }
 
     const purchaseText = createElement("span", "band-name", item.name || "商品名未入力");
-    const costText = createElement("span", "band-cost", `${formatCurrency(calculateMonthlyCostWithAdditionalCosts(item))} /月`);
+    const costText = createElement("span", "band-cost", `${formatCurrency(timelineMonthlyCost(item))} /月`);
     band.append(purchaseText, costText);
 
     if (item.endOfUseDate && unusedPeriodWidth > 0) {
@@ -378,14 +391,17 @@ function openItemNameDialog(item) {
   if (!item || !itemNameDialog) return;
   dialogItemName.textContent = item.name || "商品名未入力";
   dialogItemMeta.textContent = `購入金額${formatCurrency(Number(item.purchasePrice || 0))} / ${formatCurrency(
-    calculateMonthlyCostWithAdditionalCosts(item)
+    timelineMonthlyCost(item)
   )} /月`;
   itemNameDialog.showModal();
 }
 
 async function refreshList() {
   const loadedItems = await loadItems(state.uid);
-  state.items = loadedItems.filter((item) => !isPcManagementItem(item));
+  state.items =
+    TIMELINE_MODE === "hidden"
+      ? loadedItems.filter((item) => item.hideFromTimeline)
+      : loadedItems.filter((item) => !isPcManagementItem(item) && !item.hideFromTimeline);
   if (!state.items.some((item) => item.id === state.selectedItemId)) {
     state.selectedItemId = state.items[0]?.id ?? null;
   }
@@ -396,19 +412,23 @@ async function refreshList() {
 summarizeItems([]);
 renderEmptyTimeline();
 
-createButton.addEventListener("click", () => {
-  window.location.href = "form.html";
-});
+if (createButton) {
+  createButton.addEventListener("click", () => {
+    window.location.href = "form.html";
+  });
+}
 
-logoutButton.addEventListener("click", async () => {
-  authError.textContent = "";
-  try {
-    await logout();
-    window.location.href = "login.html";
-  } catch (error) {
-    authError.textContent = firebaseErrorMessage(error, "ログアウトに失敗しました。");
-  }
-});
+if (logoutButton) {
+  logoutButton.addEventListener("click", async () => {
+    authError.textContent = "";
+    try {
+      await logout();
+      window.location.href = "login.html";
+    } catch (error) {
+      authError.textContent = firebaseErrorMessage(error, "ログアウトに失敗しました。");
+    }
+  });
+}
 
 itemList.addEventListener("click", (event) => {
   const target = event.target;
@@ -423,6 +443,10 @@ itemList.addEventListener("click", (event) => {
 dialogEditButton.addEventListener("click", () => {
   const item = selectedItem();
   if (!item) return;
+  if (isPcManagementItem(item)) {
+    window.location.href = `pc-management/index.html?id=${encodeURIComponent(item.id)}`;
+    return;
+  }
   window.location.href = `form.html?id=${encodeURIComponent(item.id)}`;
 });
 
@@ -454,17 +478,19 @@ itemNameDialog.addEventListener("click", (event) => {
   if (event.target === itemNameDialog) itemNameDialog.close();
 });
 
-helpButton.addEventListener("click", () => {
-  helpDialog.showModal();
-});
+if (helpButton && helpDialog && helpCloseButton) {
+  helpButton.addEventListener("click", () => {
+    helpDialog.showModal();
+  });
 
-helpCloseButton.addEventListener("click", () => {
-  helpDialog.close();
-});
+  helpCloseButton.addEventListener("click", () => {
+    helpDialog.close();
+  });
 
-helpDialog.addEventListener("click", (event) => {
-  if (event.target === helpDialog) helpDialog.close();
-});
+  helpDialog.addEventListener("click", (event) => {
+    if (event.target === helpDialog) helpDialog.close();
+  });
+}
 
 window.addEventListener("resize", () => {
   window.clearTimeout(state.resizeTimer);

--- a/js/list.js
+++ b/js/list.js
@@ -3,7 +3,6 @@ import {
   logout,
   loadItems,
   removeItem,
-  calculateAdditionalCostTotal,
   calculateMonthlyCostWithAdditionalCosts,
   formatCurrency,
   getCategoryLabel,
@@ -21,13 +20,11 @@ const summaryMonthlyCost = document.getElementById("summary-monthly-cost");
 const summaryPurchaseTotal = document.getElementById("summary-purchase-total");
 const summaryItemCount = document.getElementById("summary-item-count");
 
-const detailName = document.getElementById("detail-name");
-const detailContent = document.getElementById("detail-content");
-const detailEditButton = document.getElementById("detail-edit-button");
-const detailDeleteButton = document.getElementById("detail-delete-button");
 const itemNameDialog = document.getElementById("item-name-dialog");
 const dialogItemName = document.getElementById("dialog-item-name");
 const dialogItemMeta = document.getElementById("dialog-item-meta");
+const dialogEditButton = document.getElementById("dialog-edit-button");
+const dialogDeleteButton = document.getElementById("dialog-delete-button");
 const dialogCloseButton = document.getElementById("dialog-close-button");
 
 const TIMELINE_MIN_YEAR = 2015;
@@ -73,7 +70,18 @@ function itemStartMonth(item) {
 }
 
 function itemEndMonth(item) {
+  const endOfUseDate = parseDate(item.endOfUseDate);
+  if (endOfUseDate) {
+    return Math.max(itemStartMonth(item), toMonthIndex(endOfUseDate));
+  }
   return itemStartMonth(item) + Math.max(Number(item.yearsOfUse) || 1, 1) * 12;
+}
+
+function itemEndLabel(item, endMonth) {
+  if (item.endOfUseDate) {
+    return `${formatYearMonthFromIndex(endMonth)} (使用終了)`;
+  }
+  return `${formatYearMonthFromIndex(endMonth)} (${item.yearsOfUse}年)`;
 }
 
 function timelineLayout() {
@@ -241,7 +249,7 @@ function renderTimeline(items) {
     const endLabel = createElement(
       "span",
       `timeline-end-label status-${status}`,
-      `${formatYearMonthFromIndex(endMonth)} (${item.yearsOfUse}年)`
+      itemEndLabel(item, endMonth)
     );
     endLabel.style.left = `${left + width + 10}px`;
 
@@ -255,44 +263,6 @@ function renderTimeline(items) {
   itemList.appendChild(scroll);
 }
 
-function createDetailMetric(label, value) {
-  const wrapper = createElement("div", "detail-metric");
-  const labelElement = createElement("span", "", label);
-  const valueElement = createElement("strong", "", value);
-  wrapper.append(labelElement, valueElement);
-  return wrapper;
-}
-
-function renderDetail(item) {
-  if (!item) {
-    detailName.textContent = "商品を選択してください";
-    detailContent.innerHTML = '<p class="empty">帯をタップすると詳細を表示します。</p>';
-    detailEditButton.disabled = true;
-    detailDeleteButton.disabled = true;
-    return;
-  }
-
-  const startMonth = itemStartMonth(item);
-  const endMonth = itemEndMonth(item);
-  const additionalCostTotal = calculateAdditionalCostTotal(item);
-
-  detailName.textContent = item.name;
-  detailContent.innerHTML = "";
-  detailContent.append(
-    createDetailMetric("分類", getCategoryLabel(item.category)),
-    createDetailMetric("型番", item.model || "未入力"),
-    createDetailMetric("購入日", item.purchaseDate || "未入力"),
-    createDetailMetric("耐用終了予定", formatYearMonthFromIndex(endMonth)),
-    createDetailMetric("予定耐用年数", `${item.yearsOfUse} 年`),
-    createDetailMetric("購入金額", formatCurrency(item.purchasePrice)),
-    createDetailMetric("追加費用", formatCurrency(additionalCostTotal)),
-    createDetailMetric("月額コスト", `${formatCurrency(calculateMonthlyCostWithAdditionalCosts(item))} /月`),
-    createDetailMetric("ライフサイクル", `${formatYearMonthFromIndex(startMonth)} - ${formatYearMonthFromIndex(endMonth)}`)
-  );
-  detailEditButton.disabled = false;
-  detailDeleteButton.disabled = false;
-}
-
 function selectedItem() {
   return state.items.find((item) => item.id === state.selectedItemId) ?? null;
 }
@@ -301,7 +271,6 @@ function selectItem(itemId) {
   state.selectedItemId = itemId;
   renderTimeline(state.items);
   const item = selectedItem();
-  renderDetail(item);
   openItemNameDialog(item);
 }
 
@@ -321,12 +290,10 @@ async function refreshList() {
   }
   summarizeItems(state.items);
   renderTimeline(state.items);
-  renderDetail(selectedItem());
 }
 
 summarizeItems([]);
 renderEmptyTimeline();
-renderDetail(null);
 
 createButton.addEventListener("click", () => {
   window.location.href = "form.html";
@@ -352,13 +319,13 @@ itemList.addEventListener("click", (event) => {
   selectItem(band.dataset.id ?? "");
 });
 
-detailEditButton.addEventListener("click", () => {
+dialogEditButton.addEventListener("click", () => {
   const item = selectedItem();
   if (!item) return;
   window.location.href = `form.html?id=${encodeURIComponent(item.id)}`;
 });
 
-detailDeleteButton.addEventListener("click", async () => {
+dialogDeleteButton.addEventListener("click", async () => {
   const item = selectedItem();
   if (!item || !state.uid) return;
   const shouldDelete = confirm(`「${item.name}」を削除しますか？`);
@@ -366,14 +333,15 @@ detailDeleteButton.addEventListener("click", async () => {
 
   authError.textContent = "";
   try {
-    detailDeleteButton.disabled = true;
+    dialogDeleteButton.disabled = true;
     await removeItem(state.uid, item.id);
+    itemNameDialog.close();
     state.selectedItemId = null;
     await refreshList();
   } catch (error) {
     authError.textContent = firebaseErrorMessage(error, "削除に失敗しました。");
   } finally {
-    detailDeleteButton.disabled = false;
+    dialogDeleteButton.disabled = false;
   }
 });
 

--- a/js/list.js
+++ b/js/list.js
@@ -400,7 +400,7 @@ async function refreshList() {
   const loadedItems = await loadItems(state.uid);
   state.items =
     TIMELINE_MODE === "hidden"
-      ? loadedItems.filter((item) => item.hideFromTimeline)
+      ? loadedItems.filter((item) => !isPcManagementItem(item) && item.hideFromTimeline)
       : loadedItems.filter((item) => !isPcManagementItem(item) && !item.hideFromTimeline);
   if (!state.items.some((item) => item.id === state.selectedItemId)) {
     state.selectedItemId = state.items[0]?.id ?? null;

--- a/js/list.js
+++ b/js/list.js
@@ -25,16 +25,23 @@ const detailName = document.getElementById("detail-name");
 const detailContent = document.getElementById("detail-content");
 const detailEditButton = document.getElementById("detail-edit-button");
 const detailDeleteButton = document.getElementById("detail-delete-button");
+const itemNameDialog = document.getElementById("item-name-dialog");
+const dialogItemName = document.getElementById("dialog-item-name");
+const dialogItemMeta = document.getElementById("dialog-item-meta");
+const dialogCloseButton = document.getElementById("dialog-close-button");
 
 const TIMELINE_MIN_YEAR = 2015;
 const TIMELINE_MAX_YEAR = 2055;
-const YEAR_WIDTH = 168;
-const LABEL_WIDTH = 230;
+const DESKTOP_YEAR_WIDTH = 168;
+const DESKTOP_LABEL_WIDTH = 230;
+const MOBILE_YEAR_WIDTH = 28;
+const MOBILE_LABEL_WIDTH = 72;
 
 const state = {
   uid: null,
   items: [],
   selectedItemId: null,
+  resizeTimer: null,
 };
 
 function createElement(tagName, className, textContent = "") {
@@ -69,6 +76,15 @@ function itemEndMonth(item) {
   return itemStartMonth(item) + Math.max(Number(item.yearsOfUse) || 1, 1) * 12;
 }
 
+function timelineLayout() {
+  const isCompact = window.matchMedia("(max-width: 640px)").matches;
+  return {
+    isCompact,
+    labelWidth: isCompact ? MOBILE_LABEL_WIDTH : DESKTOP_LABEL_WIDTH,
+    yearWidth: isCompact ? MOBILE_YEAR_WIDTH : DESKTOP_YEAR_WIDTH,
+  };
+}
+
 function resolveTimelineRange(items) {
   let minYear = TIMELINE_MIN_YEAR;
   let maxYear = TIMELINE_MAX_YEAR;
@@ -79,6 +95,20 @@ function resolveTimelineRange(items) {
   }
 
   return { minYear, maxYear };
+}
+
+function displayApplianceType(item) {
+  const text = `${item.name ?? ""} ${item.model ?? ""} ${getCategoryLabel(item.category)}`.toLowerCase();
+  if (item.category === "tv") return "テレビ";
+  if (item.category === "cooking_appliance") return "調理家電";
+  if (item.category === "washing_machine") return "洗濯機";
+  if (item.category === "pc" || /pc|パソコン|ノート|デスクトップ|mac|windows/.test(text)) return "パソコン";
+  if (/テレビ|tv|有機el|液晶/.test(text)) return "テレビ";
+  if (/洗濯|乾燥機|ランドリー/.test(text)) return "洗濯機";
+  if (/炊飯|電子レンジ|レンジ|オーブン|トースター|ih|調理|コンロ|ミキサー|ホットプレート/.test(text)) {
+    return "調理家電";
+  }
+  return "その他";
 }
 
 function calculateLifecycleProgress(item) {
@@ -123,18 +153,20 @@ function renderEmptyTimeline() {
 }
 
 function renderAxis(grid, minYear, maxYear, positionClass) {
+  const { isCompact, labelWidth, yearWidth } = timelineLayout();
   const axis = createElement("div", `timeline-axis ${positionClass}`);
   const yearCount = maxYear - minYear;
 
   for (let year = minYear; year <= maxYear; year += 1) {
+    if (isCompact && year % 5 !== 0) continue;
     const marker = createElement("span", "timeline-year", String(year));
-    marker.style.left = `${LABEL_WIDTH + (year - minYear) * YEAR_WIDTH}px`;
+    marker.style.left = `${labelWidth + (year - minYear) * yearWidth}px`;
     axis.appendChild(marker);
   }
 
   for (let index = 0; index <= yearCount * 12; index += 1) {
     const tick = createElement("span", index % 12 === 0 ? "timeline-tick major" : "timeline-tick");
-    tick.style.left = `${LABEL_WIDTH + (index / 12) * YEAR_WIDTH}px`;
+    tick.style.left = `${labelWidth + (index / 12) * yearWidth}px`;
     axis.appendChild(tick);
   }
 
@@ -142,6 +174,7 @@ function renderAxis(grid, minYear, maxYear, positionClass) {
 }
 
 function renderCurrentLine(grid, minYear, maxYear) {
+  const { labelWidth, yearWidth } = timelineLayout();
   const now = new Date();
   const minMonth = minYear * 12;
   const maxMonth = maxYear * 12;
@@ -150,7 +183,7 @@ function renderCurrentLine(grid, minYear, maxYear) {
   if (nowPosition < minMonth || nowPosition > maxMonth) return;
 
   const currentLine = createElement("div", "timeline-current-line");
-  currentLine.style.left = `${LABEL_WIDTH + ((nowPosition - minMonth) / 12) * YEAR_WIDTH}px`;
+  currentLine.style.left = `${labelWidth + ((nowPosition - minMonth) / 12) * yearWidth}px`;
   currentLine.innerHTML = '<span>現在</span>';
   grid.appendChild(currentLine);
 }
@@ -163,7 +196,8 @@ function renderTimeline(items) {
   }
 
   const { minYear, maxYear } = resolveTimelineRange(items);
-  const timelineWidth = LABEL_WIDTH + (maxYear - minYear) * YEAR_WIDTH;
+  const { labelWidth, yearWidth } = timelineLayout();
+  const timelineWidth = labelWidth + (maxYear - minYear) * yearWidth;
   const minMonth = minYear * 12;
 
   const scroll = createElement("div", "timeline-scroll");
@@ -172,7 +206,8 @@ function renderTimeline(items) {
 
   const grid = createElement("div", "timeline-grid");
   grid.style.width = `${timelineWidth}px`;
-  grid.style.setProperty("--label-width", `${LABEL_WIDTH}px`);
+  grid.style.setProperty("--label-width", `${labelWidth}px`);
+  grid.style.setProperty("--year-width", `${yearWidth}px`);
 
   renderAxis(grid, minYear, maxYear, "timeline-axis-top");
   renderCurrentLine(grid, minYear, maxYear);
@@ -182,14 +217,14 @@ function renderTimeline(items) {
     const startMonth = itemStartMonth(item);
     const endMonth = itemEndMonth(item);
     const status = lifecycleStatus(item);
-    const left = LABEL_WIDTH + ((startMonth - minMonth) / 12) * YEAR_WIDTH;
-    const width = Math.max(((endMonth - startMonth) / 12) * YEAR_WIDTH, 84);
+    const left = labelWidth + ((startMonth - minMonth) / 12) * yearWidth;
+    const width = Math.max(((endMonth - startMonth) / 12) * yearWidth, timelineLayout().isCompact ? 32 : 84);
     const isSelected = item.id === state.selectedItemId;
 
     const row = createElement("div", "timeline-row");
     const label = createElement("div", "timeline-row-label");
     label.innerHTML = `<span class="status-swatch status-${status}"></span><strong></strong>`;
-    label.querySelector("strong").textContent = item.name;
+    label.querySelector("strong").textContent = displayApplianceType(item);
 
     const band = createElement("button", `lifecycle-band status-${status}`);
     band.type = "button";
@@ -265,7 +300,18 @@ function selectedItem() {
 function selectItem(itemId) {
   state.selectedItemId = itemId;
   renderTimeline(state.items);
-  renderDetail(selectedItem());
+  const item = selectedItem();
+  renderDetail(item);
+  openItemNameDialog(item);
+}
+
+function openItemNameDialog(item) {
+  if (!item || !itemNameDialog) return;
+  dialogItemName.textContent = item.name || "商品名未入力";
+  dialogItemMeta.textContent = `${displayApplianceType(item)} / ${formatCurrency(
+    calculateMonthlyCostWithAdditionalCosts(item)
+  )} /月`;
+  itemNameDialog.showModal();
 }
 
 async function refreshList() {
@@ -329,6 +375,21 @@ detailDeleteButton.addEventListener("click", async () => {
   } finally {
     detailDeleteButton.disabled = false;
   }
+});
+
+dialogCloseButton.addEventListener("click", () => {
+  itemNameDialog.close();
+});
+
+itemNameDialog.addEventListener("click", (event) => {
+  if (event.target === itemNameDialog) itemNameDialog.close();
+});
+
+window.addEventListener("resize", () => {
+  window.clearTimeout(state.resizeTimer);
+  state.resizeTimer = window.setTimeout(() => {
+    renderTimeline(state.items);
+  }, 120);
 });
 
 onAuthChanged(async (user) => {

--- a/js/list.js
+++ b/js/list.js
@@ -12,11 +12,13 @@ import {
   registerServiceWorker,
 } from "./common.js";
 
-const authStatus = document.getElementById("auth-status");
 const authError = document.getElementById("auth-error");
 const logoutButton = document.getElementById("logout-button");
 const createButton = document.getElementById("create-button");
 const itemList = document.getElementById("item-list");
+const helpButton = document.getElementById("help-button");
+const helpDialog = document.getElementById("help-dialog");
+const helpCloseButton = document.getElementById("help-close-button");
 
 const summaryMonthlyCost = document.getElementById("summary-monthly-cost");
 const summaryPurchaseTotal = document.getElementById("summary-purchase-total");
@@ -115,6 +117,18 @@ function itemEndMonth(item) {
   return Math.max(itemPlannedEndMonth(item), itemActualEndMonth(item));
 }
 
+function itemUnusedPeriodEndMonth(item) {
+  if (!item.endOfUseDate) return itemEndMonth(item);
+  return itemPlannedEndMonth(item);
+}
+
+function itemTimelineEndMonth(item) {
+  if (item.endOfUseDate) {
+    return Math.max(itemEndMonth(item), itemUnusedPeriodEndMonth(item));
+  }
+  return itemEndMonth(item);
+}
+
 function itemEndLabel(item, endMonth) {
   if (item.endOfUseDate) {
     return `${formatYearMonthFromIndex(endMonth)} (使用終了)`;
@@ -137,7 +151,7 @@ function resolveTimelineRange(items) {
 
   for (const item of items) {
     minYear = Math.min(minYear, Math.floor(itemStartMonth(item) / 12));
-    maxYear = Math.max(maxYear, Math.ceil(itemEndMonth(item) / 12));
+    maxYear = Math.max(maxYear, Math.ceil(itemTimelineEndMonth(item) / 12));
   }
 
   return { minYear, maxYear };
@@ -187,7 +201,7 @@ function summarizeItems(items) {
     (total, item) => total + calculateMonthlyCostWithAdditionalCosts(item),
     0
   );
-  const purchaseTotal = items.reduce((total, item) => total + Number(item.purchasePrice || 0), 0);
+  const purchaseTotal = activeItems.reduce((total, item) => total + Number(item.purchasePrice || 0), 0);
 
   summaryMonthlyCost.textContent = `${formatCurrency(monthlyCostTotal)} /月`;
   summaryPurchaseTotal.textContent = formatCurrency(purchaseTotal);
@@ -289,10 +303,13 @@ function renderTimeline(items) {
   for (const item of sortedItems) {
     const startMonth = itemStartMonth(item);
     const endMonth = itemEndMonth(item);
+    const unusedPeriodEndMonth = itemUnusedPeriodEndMonth(item);
     const plannedEndMonth = itemPlannedEndMonth(item);
     const status = lifecycleStatus(item);
     const left = labelWidth + ((startMonth - minMonth) / 12) * yearWidth;
     const width = Math.max(((endMonth - startMonth) / 12) * yearWidth, timelineLayout().isCompact ? 32 : 84);
+    const unusedPeriodLeft = labelWidth + ((endMonth - minMonth) / 12) * yearWidth;
+    const unusedPeriodWidth = ((unusedPeriodEndMonth - endMonth) / 12) * yearWidth;
     const overuseStartPercent = ((plannedEndMonth - startMonth) / Math.max(endMonth - startMonth, 1)) * 100;
     const isOverused = itemActualEndMonth(item) > plannedEndMonth;
     const isSelected = item.id === state.selectedItemId;
@@ -316,6 +333,17 @@ function renderTimeline(items) {
     const purchaseText = createElement("span", "band-name", item.name || "商品名未入力");
     const costText = createElement("span", "band-cost", `${formatCurrency(calculateMonthlyCostWithAdditionalCosts(item))} /月`);
     band.append(purchaseText, costText);
+
+    if (item.endOfUseDate && unusedPeriodWidth > 0) {
+      const postEndBand = createElement("button", "post-end-band");
+      postEndBand.type = "button";
+      postEndBand.dataset.id = item.id;
+      postEndBand.setAttribute("aria-pressed", String(isSelected));
+      postEndBand.setAttribute("aria-label", `${item.name}の使えなかった期間`);
+      postEndBand.style.left = `${unusedPeriodLeft}px`;
+      postEndBand.style.width = `${Math.max(unusedPeriodWidth, 2)}px`;
+      row.appendChild(postEndBand);
+    }
 
     const endLabel = createElement(
       "span",
@@ -349,7 +377,7 @@ function selectItem(itemId) {
 function openItemNameDialog(item) {
   if (!item || !itemNameDialog) return;
   dialogItemName.textContent = item.name || "商品名未入力";
-  dialogItemMeta.textContent = `${displayApplianceType(item)} / ${formatCurrency(
+  dialogItemMeta.textContent = `購入金額${formatCurrency(Number(item.purchasePrice || 0))} / ${formatCurrency(
     calculateMonthlyCostWithAdditionalCosts(item)
   )} /月`;
   itemNameDialog.showModal();
@@ -386,7 +414,7 @@ itemList.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
 
-  const band = target.closest(".lifecycle-band");
+  const band = target.closest(".lifecycle-band, .post-end-band");
   if (!(band instanceof HTMLButtonElement)) return;
 
   selectItem(band.dataset.id ?? "");
@@ -426,6 +454,18 @@ itemNameDialog.addEventListener("click", (event) => {
   if (event.target === itemNameDialog) itemNameDialog.close();
 });
 
+helpButton.addEventListener("click", () => {
+  helpDialog.showModal();
+});
+
+helpCloseButton.addEventListener("click", () => {
+  helpDialog.close();
+});
+
+helpDialog.addEventListener("click", (event) => {
+  if (event.target === helpDialog) helpDialog.close();
+});
+
 window.addEventListener("resize", () => {
   window.clearTimeout(state.resizeTimer);
   state.resizeTimer = window.setTimeout(() => {
@@ -439,7 +479,6 @@ onAuthChanged(async (user) => {
     return;
   }
   state.uid = user.uid;
-  authStatus.textContent = `状態: ログイン中 (${user.email ?? "メール未設定"})`;
   try {
     await refreshList();
   } catch (error) {

--- a/js/list.js
+++ b/js/list.js
@@ -3,15 +3,10 @@ import {
   logout,
   loadItems,
   removeItem,
-  calculateMonthlyCost,
   calculateAdditionalCostTotal,
   calculateMonthlyCostWithAdditionalCosts,
-  calculateUsageMonths,
-  calculateActualMonthlyCost,
   formatCurrency,
   getCategoryLabel,
-  CATEGORY_OPTIONS,
-  escapeHtml,
   firebaseErrorMessage,
   registerServiceWorker,
 } from "./common.js";
@@ -20,202 +15,275 @@ const authStatus = document.getElementById("auth-status");
 const authError = document.getElementById("auth-error");
 const logoutButton = document.getElementById("logout-button");
 const createButton = document.getElementById("create-button");
-const categoryButtons = document.getElementById("category-buttons");
 const itemList = document.getElementById("item-list");
 
-const detailDialog = document.getElementById("detail-dialog");
+const summaryMonthlyCost = document.getElementById("summary-monthly-cost");
+const summaryPurchaseTotal = document.getElementById("summary-purchase-total");
+const summaryItemCount = document.getElementById("summary-item-count");
+
 const detailName = document.getElementById("detail-name");
+const detailContent = document.getElementById("detail-content");
 const detailEditButton = document.getElementById("detail-edit-button");
 const detailDeleteButton = document.getElementById("detail-delete-button");
-const detailCloseButton = document.getElementById("detail-close-button");
 
-const PC_MANAGEMENT_URL = "pc-management/index.html";
+const TIMELINE_MIN_YEAR = 2015;
+const TIMELINE_MAX_YEAR = 2055;
+const YEAR_WIDTH = 168;
+const LABEL_WIDTH = 230;
 
 const state = {
   uid: null,
   items: [],
   selectedItemId: null,
-  selectedCategory: "",
 };
 
-function renderCategoryPrompt() {
-  itemList.innerHTML = '<div class="empty">分類を選択してください。</div>';
+function createElement(tagName, className, textContent = "") {
+  const element = document.createElement(tagName);
+  if (className) element.className = className;
+  if (textContent) element.textContent = textContent;
+  return element;
 }
 
-function calculateActiveMonthlyCostTotal(categoryValue) {
-  return state.items
-    .filter((item) => item.category === categoryValue && !item.endOfUseDate)
-    .reduce((total, item) => total + calculateMonthlyCostWithAdditionalCosts(item), 0);
+function parseDate(value) {
+  if (!value) return null;
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
-function renderCategoryButtons() {
-  categoryButtons.innerHTML = "";
-
-  for (const category of CATEGORY_OPTIONS) {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "category-button";
-    button.dataset.category = category.value;
-    button.setAttribute("aria-pressed", String(state.selectedCategory === category.value));
-
-    const label = document.createElement("span");
-    label.className = "category-button-label";
-    label.textContent = category.label;
-
-    const total = document.createElement("span");
-    total.className = "category-button-total";
-    total.textContent = formatCurrency(calculateActiveMonthlyCostTotal(category.value));
-
-    button.append(label, total);
-    categoryButtons.appendChild(button);
-  }
-
-  const pcManagementLink = document.createElement("a");
-  pcManagementLink.className = "category-button pc-management-category-link";
-  pcManagementLink.href = PC_MANAGEMENT_URL;
-  pcManagementLink.setAttribute("aria-label", "パソコン管理を開く");
-
-  const label = document.createElement("span");
-  label.className = "category-button-label";
-  label.textContent = "パソコン管理";
-
-  const total = document.createElement("span");
-  total.className = "category-button-total";
-  total.textContent = "開く";
-
-  pcManagementLink.append(label, total);
-  categoryButtons.appendChild(pcManagementLink);
+function toMonthIndex(date) {
+  return date.getFullYear() * 12 + date.getMonth();
 }
 
-function renderList(items) {
-  itemList.innerHTML = "";
-  if (items.length === 0) {
-    itemList.innerHTML = '<div class="empty">この分類の商品はまだ登録されていません。</div>';
-    return;
-  }
+function formatYearMonthFromIndex(monthIndex) {
+  const year = Math.floor(monthIndex / 12);
+  const month = (monthIndex % 12) + 1;
+  return `${year}/${String(month).padStart(2, "0")}`;
+}
+
+function itemStartMonth(item) {
+  const purchaseDate = parseDate(item.purchaseDate);
+  return purchaseDate ? toMonthIndex(purchaseDate) : TIMELINE_MIN_YEAR * 12;
+}
+
+function itemEndMonth(item) {
+  return itemStartMonth(item) + Math.max(Number(item.yearsOfUse) || 1, 1) * 12;
+}
+
+function resolveTimelineRange(items) {
+  let minYear = TIMELINE_MIN_YEAR;
+  let maxYear = TIMELINE_MAX_YEAR;
 
   for (const item of items) {
-    const usageMonths = calculateUsageMonths(item.purchaseDate, item.endOfUseDate);
-    const additionalCostTotal = calculateAdditionalCostTotal(item);
-    const actualMonthlyCost = calculateActualMonthlyCost(item);
-    const usageMonthsText = usageMonths ? `${usageMonths}か月` : "未入力";
-    const actualCostText = actualMonthlyCost !== null ? formatCurrency(actualMonthlyCost) : "未入力";
-
-    const card = document.createElement("article");
-    card.className = "item-card";
-    if (item.endOfUseDate) card.classList.add("ended-use");
-    card.dataset.id = item.id;
-    card.tabIndex = 0;
-    card.setAttribute("role", "button");
-    card.setAttribute("aria-label", `${item.name}の操作を開く`);
-
-    card.innerHTML = `
-      <div class="item-header">
-        <h3 class="item-name">
-          <button type="button" class="item-name-button" data-id="${item.id}">
-            ${escapeHtml(item.name)}
-          </button>
-        </h3>
-      </div>
-      <p class="item-meta">型番: ${escapeHtml(item.model)} / 分類: ${escapeHtml(getCategoryLabel(item.category))} / 購入日: ${escapeHtml(item.purchaseDate)}</p>
-      <div class="costs">
-        <div class="cost-row">
-          <span class="cost-label">本体のみの月額コスト</span>
-          <span class="cost-value">${formatCurrency(calculateMonthlyCost(item))}</span>
-        </div>
-        <div class="cost-row">
-          <span class="cost-label">追加費用込みの月額コスト</span>
-          <span class="cost-value">${formatCurrency(calculateMonthlyCostWithAdditionalCosts(item))}</span>
-        </div>
-        <div class="cost-row">
-          <span class="cost-label">実質月額コスト</span>
-          <span class="cost-value">${actualCostText}</span>
-        </div>
-      </div>
-      <p class="item-meta">購入価格: ${formatCurrency(item.purchasePrice)}</p>
-      <p class="item-meta">追加費用合計: ${formatCurrency(additionalCostTotal)}</p>
-      <p class="item-meta">使用年数: ${item.yearsOfUse}年</p>
-      <p class="item-meta">使用終了日: ${item.endOfUseDate ? escapeHtml(item.endOfUseDate) : "未入力"}</p>
-      <p class="item-meta">使用月数: ${usageMonthsText}</p>
-    `;
-    itemList.appendChild(card);
+    minYear = Math.min(minYear, Math.floor(itemStartMonth(item) / 12));
+    maxYear = Math.max(maxYear, Math.ceil(itemEndMonth(item) / 12));
   }
+
+  return { minYear, maxYear };
 }
 
-function createPcManagementLauncher() {
-  const card = document.createElement("article");
-  card.className = "pc-launch-card";
-
-  const title = document.createElement("h3");
-  title.textContent = "自作PC管理";
-
-  const description = document.createElement("p");
-  description.textContent =
-    "CPU・GPU・メモリ・SSDなどのスペック、追加購入費、総投資額をPC専用画面で管理します。";
-
-  const launchButton = document.createElement("button");
-  launchButton.type = "button";
-  launchButton.className = "primary-button pc-launch-button";
-  launchButton.textContent = "PC管理アプリを起動";
-  launchButton.addEventListener("click", () => {
-    window.location.href = PC_MANAGEMENT_URL;
-  });
-
-  card.append(title, description, launchButton);
-  return card;
+function calculateLifecycleProgress(item) {
+  const now = new Date();
+  const nowMonth = toMonthIndex(now);
+  const startMonth = itemStartMonth(item);
+  const durationMonths = Math.max(itemEndMonth(item) - startMonth, 1);
+  return (nowMonth - startMonth) / durationMonths;
 }
 
-function renderFilteredList() {
-  if (!state.selectedCategory) {
-    renderCategoryPrompt();
+function lifecycleStatus(item) {
+  if (item.endOfUseDate) return "ended";
+
+  const progress = calculateLifecycleProgress(item);
+  if (progress >= 1) return "ended";
+  if (progress >= 0.85) return "danger";
+  if (progress >= 0.5) return "warning";
+  return "normal";
+}
+
+function summarizeItems(items) {
+  const activeItems = items.filter((item) => !item.endOfUseDate && lifecycleStatus(item) !== "ended");
+  const monthlyCostTotal = activeItems.reduce(
+    (total, item) => total + calculateMonthlyCostWithAdditionalCosts(item),
+    0
+  );
+  const purchaseTotal = items.reduce((total, item) => total + Number(item.purchasePrice || 0), 0);
+
+  summaryMonthlyCost.textContent = `${formatCurrency(monthlyCostTotal)} /月`;
+  summaryPurchaseTotal.textContent = formatCurrency(purchaseTotal);
+  summaryItemCount.textContent = `${items.length} 件`;
+}
+
+function renderEmptyTimeline() {
+  itemList.innerHTML = "";
+  const empty = createElement("div", "timeline-empty");
+  empty.innerHTML = `
+    <strong>登録データがありません</strong>
+    <span>家電を登録すると、購入日から耐用年数までのライフサイクル帯を表示します。</span>
+  `;
+  itemList.appendChild(empty);
+}
+
+function renderAxis(grid, minYear, maxYear, positionClass) {
+  const axis = createElement("div", `timeline-axis ${positionClass}`);
+  const yearCount = maxYear - minYear;
+
+  for (let year = minYear; year <= maxYear; year += 1) {
+    const marker = createElement("span", "timeline-year", String(year));
+    marker.style.left = `${LABEL_WIDTH + (year - minYear) * YEAR_WIDTH}px`;
+    axis.appendChild(marker);
+  }
+
+  for (let index = 0; index <= yearCount * 12; index += 1) {
+    const tick = createElement("span", index % 12 === 0 ? "timeline-tick major" : "timeline-tick");
+    tick.style.left = `${LABEL_WIDTH + (index / 12) * YEAR_WIDTH}px`;
+    axis.appendChild(tick);
+  }
+
+  grid.appendChild(axis);
+}
+
+function renderCurrentLine(grid, minYear, maxYear) {
+  const now = new Date();
+  const minMonth = minYear * 12;
+  const maxMonth = maxYear * 12;
+  const nowPosition = toMonthIndex(now) + now.getDate() / 31;
+
+  if (nowPosition < minMonth || nowPosition > maxMonth) return;
+
+  const currentLine = createElement("div", "timeline-current-line");
+  currentLine.style.left = `${LABEL_WIDTH + ((nowPosition - minMonth) / 12) * YEAR_WIDTH}px`;
+  currentLine.innerHTML = '<span>現在</span>';
+  grid.appendChild(currentLine);
+}
+
+function renderTimeline(items) {
+  itemList.innerHTML = "";
+  if (items.length === 0) {
+    renderEmptyTimeline();
     return;
   }
-  renderList(state.items.filter((item) => item.category === state.selectedCategory));
-  if (state.selectedCategory === "pc") {
-    itemList.prepend(createPcManagementLauncher());
+
+  const { minYear, maxYear } = resolveTimelineRange(items);
+  const timelineWidth = LABEL_WIDTH + (maxYear - minYear) * YEAR_WIDTH;
+  const minMonth = minYear * 12;
+
+  const scroll = createElement("div", "timeline-scroll");
+  scroll.tabIndex = 0;
+  scroll.setAttribute("aria-label", "ライフサイクル年表。横にスクロールできます。");
+
+  const grid = createElement("div", "timeline-grid");
+  grid.style.width = `${timelineWidth}px`;
+  grid.style.setProperty("--label-width", `${LABEL_WIDTH}px`);
+
+  renderAxis(grid, minYear, maxYear, "timeline-axis-top");
+  renderCurrentLine(grid, minYear, maxYear);
+
+  const rows = createElement("div", "timeline-rows");
+  for (const item of items) {
+    const startMonth = itemStartMonth(item);
+    const endMonth = itemEndMonth(item);
+    const status = lifecycleStatus(item);
+    const left = LABEL_WIDTH + ((startMonth - minMonth) / 12) * YEAR_WIDTH;
+    const width = Math.max(((endMonth - startMonth) / 12) * YEAR_WIDTH, 84);
+    const isSelected = item.id === state.selectedItemId;
+
+    const row = createElement("div", "timeline-row");
+    const label = createElement("div", "timeline-row-label");
+    label.innerHTML = `<span class="status-swatch status-${status}"></span><strong></strong>`;
+    label.querySelector("strong").textContent = item.name;
+
+    const band = createElement("button", `lifecycle-band status-${status}`);
+    band.type = "button";
+    band.dataset.id = item.id;
+    band.setAttribute("aria-pressed", String(isSelected));
+    band.setAttribute("aria-label", `${item.name}の詳細を表示`);
+    band.style.left = `${left}px`;
+    band.style.width = `${width}px`;
+
+    const purchaseText = createElement("span", "band-purchase", `${formatYearMonthFromIndex(startMonth)} 購入`);
+    const costText = createElement("span", "band-cost", `${formatCurrency(calculateMonthlyCostWithAdditionalCosts(item))} /月`);
+    band.append(purchaseText, costText);
+
+    const endLabel = createElement(
+      "span",
+      `timeline-end-label status-${status}`,
+      `${formatYearMonthFromIndex(endMonth)} (${item.yearsOfUse}年)`
+    );
+    endLabel.style.left = `${left + width + 10}px`;
+
+    row.append(label, band, endLabel);
+    rows.appendChild(row);
   }
+
+  grid.appendChild(rows);
+  renderAxis(grid, minYear, maxYear, "timeline-axis-bottom");
+  scroll.appendChild(grid);
+  itemList.appendChild(scroll);
+}
+
+function createDetailMetric(label, value) {
+  const wrapper = createElement("div", "detail-metric");
+  const labelElement = createElement("span", "", label);
+  const valueElement = createElement("strong", "", value);
+  wrapper.append(labelElement, valueElement);
+  return wrapper;
+}
+
+function renderDetail(item) {
+  if (!item) {
+    detailName.textContent = "商品を選択してください";
+    detailContent.innerHTML = '<p class="empty">帯をタップすると詳細を表示します。</p>';
+    detailEditButton.disabled = true;
+    detailDeleteButton.disabled = true;
+    return;
+  }
+
+  const startMonth = itemStartMonth(item);
+  const endMonth = itemEndMonth(item);
+  const additionalCostTotal = calculateAdditionalCostTotal(item);
+
+  detailName.textContent = item.name;
+  detailContent.innerHTML = "";
+  detailContent.append(
+    createDetailMetric("分類", getCategoryLabel(item.category)),
+    createDetailMetric("型番", item.model || "未入力"),
+    createDetailMetric("購入日", item.purchaseDate || "未入力"),
+    createDetailMetric("耐用終了予定", formatYearMonthFromIndex(endMonth)),
+    createDetailMetric("予定耐用年数", `${item.yearsOfUse} 年`),
+    createDetailMetric("購入金額", formatCurrency(item.purchasePrice)),
+    createDetailMetric("追加費用", formatCurrency(additionalCostTotal)),
+    createDetailMetric("月額コスト", `${formatCurrency(calculateMonthlyCostWithAdditionalCosts(item))} /月`),
+    createDetailMetric("ライフサイクル", `${formatYearMonthFromIndex(startMonth)} - ${formatYearMonthFromIndex(endMonth)}`)
+  );
+  detailEditButton.disabled = false;
+  detailDeleteButton.disabled = false;
 }
 
 function selectedItem() {
   return state.items.find((item) => item.id === state.selectedItemId) ?? null;
 }
 
-function openDetail(item) {
-  state.selectedItemId = item.id;
-  detailName.textContent = item.name;
-  detailDialog.showModal();
+function selectItem(itemId) {
+  state.selectedItemId = itemId;
+  renderTimeline(state.items);
+  renderDetail(selectedItem());
 }
 
 async function refreshList() {
   state.items = await loadItems(state.uid);
-  renderFilteredList();
+  if (!state.items.some((item) => item.id === state.selectedItemId)) {
+    state.selectedItemId = state.items[0]?.id ?? null;
+  }
+  summarizeItems(state.items);
+  renderTimeline(state.items);
+  renderDetail(selectedItem());
 }
 
-function findCardItem(target) {
-  const card = target.closest(".item-card");
-  if (!card) return null;
-  const id = card.dataset.id;
-  if (!id) return null;
-  return state.items.find((item) => item.id === id) ?? null;
-}
-
-renderCategoryButtons();
-renderCategoryPrompt();
+summarizeItems([]);
+renderEmptyTimeline();
+renderDetail(null);
 
 createButton.addEventListener("click", () => {
   window.location.href = "form.html";
-});
-
-categoryButtons.addEventListener("click", (event) => {
-  const target = event.target;
-  if (!(target instanceof HTMLElement)) return;
-
-  const button = target.closest(".category-button");
-  if (!(button instanceof HTMLButtonElement)) return;
-
-  state.selectedCategory = button.dataset.category ?? "";
-  renderCategoryButtons();
-  renderFilteredList();
 });
 
 logoutButton.addEventListener("click", async () => {
@@ -231,18 +299,11 @@ logoutButton.addEventListener("click", async () => {
 itemList.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
-  const item = findCardItem(target);
-  if (item) openDetail(item);
-});
 
-itemList.addEventListener("keydown", (event) => {
-  if (event.key !== "Enter" && event.key !== " ") return;
-  const target = event.target;
-  if (!(target instanceof HTMLElement)) return;
-  const item = findCardItem(target);
-  if (!item) return;
-  event.preventDefault();
-  openDetail(item);
+  const band = target.closest(".lifecycle-band");
+  if (!(band instanceof HTMLButtonElement)) return;
+
+  selectItem(band.dataset.id ?? "");
 });
 
 detailEditButton.addEventListener("click", () => {
@@ -261,7 +322,6 @@ detailDeleteButton.addEventListener("click", async () => {
   try {
     detailDeleteButton.disabled = true;
     await removeItem(state.uid, item.id);
-    detailDialog.close();
     state.selectedItemId = null;
     await refreshList();
   } catch (error) {
@@ -269,14 +329,6 @@ detailDeleteButton.addEventListener("click", async () => {
   } finally {
     detailDeleteButton.disabled = false;
   }
-});
-
-detailCloseButton.addEventListener("click", () => {
-  detailDialog.close();
-});
-
-detailDialog.addEventListener("close", () => {
-  state.selectedItemId = null;
 });
 
 onAuthChanged(async (user) => {
@@ -288,7 +340,6 @@ onAuthChanged(async (user) => {
   authStatus.textContent = `状態: ログイン中 (${user.email ?? "メール未設定"})`;
   try {
     await refreshList();
-    renderCategoryButtons();
   } catch (error) {
     authError.textContent = firebaseErrorMessage(error, "データ取得に失敗しました。");
   }

--- a/js/list.js
+++ b/js/list.js
@@ -5,7 +5,9 @@ import {
   removeItem,
   calculateMonthlyCostWithAdditionalCosts,
   formatCurrency,
+  CATEGORY_OPTIONS,
   getCategoryLabel,
+  isPcManagementItem,
   firebaseErrorMessage,
   registerServiceWorker,
 } from "./common.js";
@@ -58,23 +60,59 @@ function toMonthIndex(date) {
   return date.getFullYear() * 12 + date.getMonth();
 }
 
+function daysInMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+}
+
+function toMonthPosition(date) {
+  return toMonthIndex(date) + (date.getDate() - 1) / daysInMonth(date);
+}
+
+function addYearsClamped(date, years) {
+  const targetYear = date.getFullYear() + years;
+  const targetMonth = date.getMonth();
+  const targetDay = Math.min(date.getDate(), new Date(targetYear, targetMonth + 1, 0).getDate());
+  return new Date(targetYear, targetMonth, targetDay);
+}
+
 function formatYearMonthFromIndex(monthIndex) {
-  const year = Math.floor(monthIndex / 12);
-  const month = (monthIndex % 12) + 1;
+  const normalizedMonthIndex = Math.floor(monthIndex);
+  const year = Math.floor(normalizedMonthIndex / 12);
+  const month = (normalizedMonthIndex % 12) + 1;
   return `${year}/${String(month).padStart(2, "0")}`;
 }
 
 function itemStartMonth(item) {
   const purchaseDate = parseDate(item.purchaseDate);
-  return purchaseDate ? toMonthIndex(purchaseDate) : TIMELINE_MIN_YEAR * 12;
+  return purchaseDate ? toMonthPosition(purchaseDate) : TIMELINE_MIN_YEAR * 12;
+}
+
+function currentMonthIndex() {
+  return toMonthPosition(new Date());
+}
+
+function itemPlannedEndMonth(item) {
+  const purchaseDate = parseDate(item.purchaseDate);
+  const yearsOfUse = Math.max(Number(item.yearsOfUse) || 1, 1);
+  if (!purchaseDate) {
+    return itemStartMonth(item) + yearsOfUse * 12;
+  }
+  return toMonthPosition(addYearsClamped(purchaseDate, yearsOfUse));
+}
+
+function itemActualEndMonth(item) {
+  const endOfUseDate = parseDate(item.endOfUseDate);
+  if (endOfUseDate) {
+    return Math.max(itemStartMonth(item), toMonthPosition(endOfUseDate));
+  }
+  return currentMonthIndex();
 }
 
 function itemEndMonth(item) {
-  const endOfUseDate = parseDate(item.endOfUseDate);
-  if (endOfUseDate) {
-    return Math.max(itemStartMonth(item), toMonthIndex(endOfUseDate));
+  if (item.endOfUseDate) {
+    return itemActualEndMonth(item);
   }
-  return itemStartMonth(item) + Math.max(Number(item.yearsOfUse) || 1, 1) * 12;
+  return Math.max(itemPlannedEndMonth(item), itemActualEndMonth(item));
 }
 
 function itemEndLabel(item, endMonth) {
@@ -109,11 +147,27 @@ function displayApplianceType(item) {
   return getCategoryLabel(item.category);
 }
 
+function categoryOrderIndex(categoryValue) {
+  const index = CATEGORY_OPTIONS.findIndex((category) => category.value === categoryValue);
+  return index === -1 ? CATEGORY_OPTIONS.length : index;
+}
+
+function sortItemsByCategory(items) {
+  return [...items].sort((a, b) => {
+    const categoryCompare = categoryOrderIndex(a.category) - categoryOrderIndex(b.category);
+    if (categoryCompare !== 0) return categoryCompare;
+
+    const dateCompare = String(b.purchaseDate).localeCompare(String(a.purchaseDate));
+    if (dateCompare !== 0) return dateCompare;
+    return String(a.name).localeCompare(String(b.name), "ja");
+  });
+}
+
 function calculateLifecycleProgress(item) {
   const now = new Date();
-  const nowMonth = toMonthIndex(now);
+  const nowMonth = toMonthPosition(now);
   const startMonth = itemStartMonth(item);
-  const durationMonths = Math.max(itemEndMonth(item) - startMonth, 1);
+  const durationMonths = Math.max(itemPlannedEndMonth(item) - startMonth, 1);
   return (nowMonth - startMonth) / durationMonths;
 }
 
@@ -128,7 +182,7 @@ function lifecycleStatus(item) {
 }
 
 function summarizeItems(items) {
-  const activeItems = items.filter((item) => !item.endOfUseDate && lifecycleStatus(item) !== "ended");
+  const activeItems = items.filter((item) => !item.endOfUseDate);
   const monthlyCostTotal = activeItems.reduce(
     (total, item) => total + calculateMonthlyCostWithAdditionalCosts(item),
     0
@@ -187,7 +241,7 @@ function currentLinePosition(minYear, maxYear) {
   const now = new Date();
   const minMonth = minYear * 12;
   const maxMonth = maxYear * 12;
-  const nowPosition = toMonthIndex(now) + now.getDate() / 31;
+  const nowPosition = toMonthPosition(now);
 
   if (nowPosition < minMonth || nowPosition > maxMonth) return null;
   return labelWidth + ((nowPosition - minMonth) / 12) * yearWidth;
@@ -213,7 +267,8 @@ function renderTimeline(items) {
     return;
   }
 
-  const { minYear, maxYear } = resolveTimelineRange(items);
+  const sortedItems = sortItemsByCategory(items);
+  const { minYear, maxYear } = resolveTimelineRange(sortedItems);
   const { labelWidth, yearWidth } = timelineLayout();
   const timelineWidth = labelWidth + (maxYear - minYear) * yearWidth;
   const minMonth = minYear * 12;
@@ -231,28 +286,34 @@ function renderTimeline(items) {
   renderCurrentLine(grid, minYear, maxYear);
 
   const rows = createElement("div", "timeline-rows");
-  for (const item of items) {
+  for (const item of sortedItems) {
     const startMonth = itemStartMonth(item);
     const endMonth = itemEndMonth(item);
+    const plannedEndMonth = itemPlannedEndMonth(item);
     const status = lifecycleStatus(item);
     const left = labelWidth + ((startMonth - minMonth) / 12) * yearWidth;
     const width = Math.max(((endMonth - startMonth) / 12) * yearWidth, timelineLayout().isCompact ? 32 : 84);
+    const overuseStartPercent = ((plannedEndMonth - startMonth) / Math.max(endMonth - startMonth, 1)) * 100;
+    const isOverused = itemActualEndMonth(item) > plannedEndMonth;
     const isSelected = item.id === state.selectedItemId;
 
     const row = createElement("div", "timeline-row");
     const label = createElement("div", "timeline-row-label");
-    label.innerHTML = `<span class="status-swatch status-${status}"></span><strong></strong>`;
+    label.innerHTML = `<span class="category-swatch category-${item.category}"></span><strong></strong>`;
     label.querySelector("strong").textContent = displayApplianceType(item);
 
-    const band = createElement("button", `lifecycle-band status-${status}`);
+    const band = createElement("button", `lifecycle-band category-${item.category}${isOverused ? " overused" : ""}`);
     band.type = "button";
     band.dataset.id = item.id;
     band.setAttribute("aria-pressed", String(isSelected));
     band.setAttribute("aria-label", `${item.name}の詳細を表示`);
     band.style.left = `${left}px`;
     band.style.width = `${width}px`;
+    if (isOverused) {
+      band.style.setProperty("--overuse-start", `${Math.min(Math.max(overuseStartPercent, 0), 100)}%`);
+    }
 
-    const purchaseText = createElement("span", "band-purchase", `${formatYearMonthFromIndex(startMonth)} 購入`);
+    const purchaseText = createElement("span", "band-name", item.name || "商品名未入力");
     const costText = createElement("span", "band-cost", `${formatCurrency(calculateMonthlyCostWithAdditionalCosts(item))} /月`);
     band.append(purchaseText, costText);
 
@@ -295,7 +356,8 @@ function openItemNameDialog(item) {
 }
 
 async function refreshList() {
-  state.items = await loadItems(state.uid);
+  const loadedItems = await loadItems(state.uid);
+  state.items = loadedItems.filter((item) => !isPcManagementItem(item));
   if (!state.items.some((item) => item.id === state.selectedItemId)) {
     state.selectedItemId = state.items[0]?.id ?? null;
   }

--- a/js/list.js
+++ b/js/list.js
@@ -106,17 +106,7 @@ function resolveTimelineRange(items) {
 }
 
 function displayApplianceType(item) {
-  const text = `${item.name ?? ""} ${item.model ?? ""} ${getCategoryLabel(item.category)}`.toLowerCase();
-  if (item.category === "tv") return "テレビ";
-  if (item.category === "cooking_appliance") return "調理家電";
-  if (item.category === "washing_machine") return "洗濯機";
-  if (item.category === "pc" || /pc|パソコン|ノート|デスクトップ|mac|windows/.test(text)) return "パソコン";
-  if (/テレビ|tv|有機el|液晶/.test(text)) return "テレビ";
-  if (/洗濯|乾燥機|ランドリー/.test(text)) return "洗濯機";
-  if (/炊飯|電子レンジ|レンジ|オーブン|トースター|ih|調理|コンロ|ミキサー|ホットプレート/.test(text)) {
-    return "調理家電";
-  }
-  return "その他";
+  return getCategoryLabel(item.category);
 }
 
 function calculateLifecycleProgress(item) {
@@ -182,18 +172,38 @@ function renderAxis(grid, minYear, maxYear, positionClass) {
 }
 
 function renderCurrentLine(grid, minYear, maxYear) {
+  const currentPosition = currentLinePosition(minYear, maxYear);
+
+  if (currentPosition === null) return;
+
+  const currentLine = createElement("div", "timeline-current-line");
+  currentLine.style.left = `${currentPosition}px`;
+  currentLine.innerHTML = '<span>現在</span>';
+  grid.appendChild(currentLine);
+}
+
+function currentLinePosition(minYear, maxYear) {
   const { labelWidth, yearWidth } = timelineLayout();
   const now = new Date();
   const minMonth = minYear * 12;
   const maxMonth = maxYear * 12;
   const nowPosition = toMonthIndex(now) + now.getDate() / 31;
 
-  if (nowPosition < minMonth || nowPosition > maxMonth) return;
+  if (nowPosition < minMonth || nowPosition > maxMonth) return null;
+  return labelWidth + ((nowPosition - minMonth) / 12) * yearWidth;
+}
 
-  const currentLine = createElement("div", "timeline-current-line");
-  currentLine.style.left = `${labelWidth + ((nowPosition - minMonth) / 12) * yearWidth}px`;
-  currentLine.innerHTML = '<span>現在</span>';
-  grid.appendChild(currentLine);
+function centerCurrentLine(scroll, minYear, maxYear) {
+  const currentPosition = currentLinePosition(minYear, maxYear);
+  if (currentPosition === null) return;
+  const { labelWidth } = timelineLayout();
+
+  requestAnimationFrame(() => {
+    const maxScrollLeft = Math.max(scroll.scrollWidth - scroll.clientWidth, 0);
+    const visibleTimelineWidth = Math.max(scroll.clientWidth - labelWidth, 1);
+    const targetScrollLeft = currentPosition - labelWidth - visibleTimelineWidth / 2;
+    scroll.scrollLeft = Math.min(Math.max(targetScrollLeft, 0), maxScrollLeft);
+  });
 }
 
 function renderTimeline(items) {
@@ -261,6 +271,7 @@ function renderTimeline(items) {
   renderAxis(grid, minYear, maxYear, "timeline-axis-bottom");
   scroll.appendChild(grid);
   itemList.appendChild(scroll);
+  centerCurrentLine(scroll, minYear, maxYear);
 }
 
 function selectedItem() {

--- a/list.html
+++ b/list.html
@@ -44,22 +44,6 @@
         <div id="item-list" class="timeline-shell"></div>
       </section>
 
-      <section id="detail-panel" class="panel selected-detail-panel" aria-labelledby="detail-name">
-        <div class="selected-detail-heading">
-          <div>
-            <p class="detail-kicker">選択中</p>
-            <h2 id="detail-name">商品を選択してください</h2>
-          </div>
-          <div class="detail-actions">
-            <button id="detail-edit-button" type="button" class="primary-button" disabled>編集</button>
-            <button id="detail-delete-button" type="button" class="danger-button" disabled>削除</button>
-          </div>
-        </div>
-        <div id="detail-content" class="detail-grid">
-          <p class="empty">帯をタップすると詳細を表示します。</p>
-        </div>
-      </section>
-
       <section class="pc-management-launch" aria-label="パソコン管理">
         <a class="pc-management-button" href="pc-management/index.html">パソコン管理を開く</a>
       </section>
@@ -70,7 +54,11 @@
         <p class="detail-kicker">商品名</p>
         <h2 id="dialog-item-name"></h2>
         <p id="dialog-item-meta" class="dialog-item-meta"></p>
-        <button id="dialog-close-button" type="button" class="ghost-button">閉じる</button>
+        <div class="dialog-actions">
+          <button id="dialog-edit-button" type="button" class="primary-button">編集</button>
+          <button id="dialog-delete-button" type="button" class="danger-button">削除</button>
+          <button id="dialog-close-button" type="button" class="ghost-button">閉じる</button>
+        </div>
       </article>
     </dialog>
     <script type="module" src="js/list.js"></script>

--- a/list.html
+++ b/list.html
@@ -23,7 +23,7 @@
             <strong id="summary-monthly-cost">¥0 /月</strong>
           </div>
           <div class="summary-item">
-            <span class="summary-label">総購入額</span>
+            <span class="summary-label">総購入額(現在使用中)</span>
             <strong id="summary-purchase-total">¥0</strong>
           </div>
           <div class="summary-item">
@@ -83,7 +83,6 @@
 
     <dialog id="item-name-dialog" class="item-name-dialog">
       <article class="item-name-dialog-card">
-        <p class="detail-kicker">商品名</p>
         <h2 id="dialog-item-name"></h2>
         <p id="dialog-item-meta" class="dialog-item-meta"></p>
         <div class="dialog-actions">

--- a/list.html
+++ b/list.html
@@ -4,47 +4,66 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>一覧 | 耐久消費財管理</title>
-    <meta name="theme-color" content="#2563eb" />
+    <meta name="theme-color" content="#1f2933" />
     <link rel="manifest" href="manifest.webmanifest" />
     <link rel="icon" href="icons/icon-192.png" type="image/png" />
     <link rel="apple-touch-icon" href="icons/icon-192.png" />
     <link rel="stylesheet" href="style.css" />
   </head>
-  <body>
-    <main class="app">
-      <header class="app-header">
-        <h1>耐久消費財管理</h1>
-        <p class="subtitle">一覧</p>
-      </header>
-
-      <section class="panel" aria-labelledby="list-title">
-        <h2 id="list-title">登録データ一覧</h2>
-        <p id="auth-status" class="form-mode"></p>
-        <p id="auth-error" class="form-error"></p>
-        <div class="form-actions">
-          <button id="create-button" type="button" class="primary-button">新規登録へ</button>
+  <body class="dashboard-body">
+    <main class="app dashboard-app">
+      <header class="app-header dashboard-header">
+        <div class="dashboard-title">
+          <h1>ライフサイクルコスト</h1>
+          <p class="subtitle">耐久消費財の月割りコスト管理</p>
+        </div>
+        <section class="summary-panel" aria-label="集計">
+          <div class="summary-item summary-item-primary">
+            <span class="summary-label">現在の月額合計</span>
+            <strong id="summary-monthly-cost">¥0 /月</strong>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">総購入額</span>
+            <strong id="summary-purchase-total">¥0</strong>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">登録数</span>
+            <strong id="summary-item-count">0 件</strong>
+          </div>
+        </section>
+        <div class="dashboard-actions">
+          <button id="create-button" type="button" class="primary-button">＋ 家電を登録</button>
           <button id="logout-button" type="button" class="ghost-button">ログアウト</button>
         </div>
-        <div id="category-buttons" class="category-buttons" aria-label="表示する分類">
-          <a class="category-button pc-management-category-link" href="pc-management/index.html" aria-label="パソコン管理を開く">
-            <span class="category-button-label">パソコン管理</span>
-            <span class="category-button-total">開く</span>
-          </a>
+      </header>
+
+      <section class="panel timeline-panel" aria-labelledby="list-title">
+        <h2 id="list-title">ライフサイクル年表</h2>
+        <p id="auth-status" class="form-mode"></p>
+        <p id="auth-error" class="form-error"></p>
+        <div id="item-list" class="timeline-shell"></div>
+      </section>
+
+      <section id="detail-panel" class="panel selected-detail-panel" aria-labelledby="detail-name">
+        <div class="selected-detail-heading">
+          <div>
+            <p class="detail-kicker">選択中</p>
+            <h2 id="detail-name">商品を選択してください</h2>
+          </div>
+          <div class="detail-actions">
+            <button id="detail-edit-button" type="button" class="primary-button" disabled>編集</button>
+            <button id="detail-delete-button" type="button" class="danger-button" disabled>削除</button>
+          </div>
         </div>
-        <div id="item-list" class="card-list"></div>
+        <div id="detail-content" class="detail-grid">
+          <p class="empty">帯をタップすると詳細を表示します。</p>
+        </div>
+      </section>
+
+      <section class="pc-management-launch" aria-label="パソコン管理">
+        <a class="pc-management-button" href="pc-management/index.html">パソコン管理を開く</a>
       </section>
     </main>
-
-    <dialog id="detail-dialog" class="detail-dialog">
-      <article class="detail-card">
-        <h3 id="detail-name"></h3>
-        <div class="detail-actions">
-          <button id="detail-edit-button" type="button" class="primary-button">編集</button>
-          <button id="detail-delete-button" type="button" class="danger-button">削除</button>
-          <button id="detail-close-button" type="button" class="ghost-button">閉じる</button>
-        </div>
-      </article>
-    </dialog>
     <script type="module" src="js/list.js"></script>
   </body>
 </html>

--- a/list.html
+++ b/list.html
@@ -44,6 +44,7 @@
       </section>
 
       <section class="pc-management-launch" aria-label="パソコン管理">
+        <a class="pc-management-button" href="hidden.html">非表示商品</a>
         <a class="pc-management-button" href="pc-management/index.html">パソコン管理</a>
         <button id="help-button" type="button" class="pc-management-button help-button">ヘルプ</button>
       </section>

--- a/list.html
+++ b/list.html
@@ -39,6 +39,17 @@
 
       <section class="panel timeline-panel" aria-labelledby="list-title">
         <h2 id="list-title">ライフサイクル年表</h2>
+        <div class="timeline-legend" aria-label="帯の色の凡例">
+          <span class="legend-item"><span class="legend-band category-information_device"></span>情報機器</span>
+          <span class="legend-item"><span class="legend-band category-smartphone"></span>スマホ</span>
+          <span class="legend-item"><span class="legend-band category-audio_visual"></span>映像・音響</span>
+          <span class="legend-item"><span class="legend-band category-air_conditioning"></span>空調家電</span>
+          <span class="legend-item"><span class="legend-band category-living_appliance"></span>生活家電</span>
+          <span class="legend-item"><span class="legend-band category-cooking_appliance"></span>調理家電</span>
+          <span class="legend-item"><span class="legend-band category-beauty_health"></span>美容・健康</span>
+          <span class="legend-item"><span class="legend-band category-other"></span>その他</span>
+          <span class="legend-item"><span class="legend-band legend-overused"></span>濃い部分は使用年数超過</span>
+        </div>
         <p id="auth-status" class="form-mode"></p>
         <p id="auth-error" class="form-error"></p>
         <div id="item-list" class="timeline-shell"></div>

--- a/list.html
+++ b/list.html
@@ -64,6 +64,15 @@
         <a class="pc-management-button" href="pc-management/index.html">パソコン管理を開く</a>
       </section>
     </main>
+
+    <dialog id="item-name-dialog" class="item-name-dialog">
+      <article class="item-name-dialog-card">
+        <p class="detail-kicker">商品名</p>
+        <h2 id="dialog-item-name"></h2>
+        <p id="dialog-item-meta" class="dialog-item-meta"></p>
+        <button id="dialog-close-button" type="button" class="ghost-button">閉じる</button>
+      </article>
+    </dialog>
     <script type="module" src="js/list.js"></script>
   </body>
 </html>

--- a/list.html
+++ b/list.html
@@ -32,33 +32,54 @@
           </div>
         </section>
         <div class="dashboard-actions">
-          <button id="create-button" type="button" class="primary-button">＋ 家電を登録</button>
+          <button id="create-button" type="button" class="primary-button">新規登録</button>
           <button id="logout-button" type="button" class="ghost-button">ログアウト</button>
         </div>
       </header>
 
       <section class="panel timeline-panel" aria-labelledby="list-title">
         <h2 id="list-title">ライフサイクル年表</h2>
-        <div class="timeline-legend" aria-label="帯の色の凡例">
-          <span class="legend-item"><span class="legend-band category-information_device"></span>情報機器</span>
-          <span class="legend-item"><span class="legend-band category-smartphone"></span>スマホ</span>
-          <span class="legend-item"><span class="legend-band category-audio_visual"></span>映像・音響</span>
-          <span class="legend-item"><span class="legend-band category-air_conditioning"></span>空調家電</span>
-          <span class="legend-item"><span class="legend-band category-living_appliance"></span>生活家電</span>
-          <span class="legend-item"><span class="legend-band category-cooking_appliance"></span>調理家電</span>
-          <span class="legend-item"><span class="legend-band category-beauty_health"></span>美容・健康</span>
-          <span class="legend-item"><span class="legend-band category-other"></span>その他</span>
-          <span class="legend-item"><span class="legend-band legend-overused"></span>濃い部分は使用年数超過</span>
-        </div>
-        <p id="auth-status" class="form-mode"></p>
         <p id="auth-error" class="form-error"></p>
         <div id="item-list" class="timeline-shell"></div>
       </section>
 
       <section class="pc-management-launch" aria-label="パソコン管理">
-        <a class="pc-management-button" href="pc-management/index.html">パソコン管理を開く</a>
+        <a class="pc-management-button" href="pc-management/index.html">パソコン管理</a>
+        <button id="help-button" type="button" class="pc-management-button help-button">ヘルプ</button>
       </section>
     </main>
+
+    <dialog id="help-dialog" class="help-dialog">
+      <article class="help-dialog-card">
+        <div class="help-dialog-header">
+          <h2>ヘルプ</h2>
+          <button id="help-close-button" type="button" class="ghost-button">閉じる</button>
+        </div>
+
+        <section class="help-section" aria-labelledby="help-legend-title">
+          <h3 id="help-legend-title">帯の凡例</h3>
+          <div class="timeline-legend help-legend" aria-label="帯の色の凡例">
+            <span class="legend-item"><span class="legend-band category-information_device"></span>情報機器</span>
+            <span class="legend-item"><span class="legend-band category-smartphone"></span>スマホ</span>
+            <span class="legend-item"><span class="legend-band category-audio_visual"></span>映像・音響</span>
+            <span class="legend-item"><span class="legend-band category-air_conditioning"></span>空調家電</span>
+            <span class="legend-item"><span class="legend-band category-living_appliance"></span>生活家電</span>
+            <span class="legend-item"><span class="legend-band category-cooking_appliance"></span>調理家電</span>
+            <span class="legend-item"><span class="legend-band category-beauty_health"></span>美容・健康</span>
+            <span class="legend-item"><span class="legend-band category-other"></span>その他</span>
+            <span class="legend-item"><span class="legend-band legend-overused"></span>濃い部分は使用年数超過</span>
+            <span class="legend-item"><span class="legend-band legend-unused"></span>無色部分は使用年数に達しなかった期間</span>
+          </div>
+        </section>
+
+        <section class="help-section" aria-labelledby="help-concept-title">
+          <h3 id="help-concept-title">このアプリのコンセプト</h3>
+          <p>このアプリは、家電や消耗品の購入日・購入金額・使用年数を記録し、いつまで使う予定か、どれくらいのコストで使えているかを見える化するための管理ツールです。</p>
+          <p>単に購入履歴を残すだけでなく、使用期間を年表で確認することで、買い替え時期の目安や、予定より早く使えなくなったものを把握しやすくします。</p>
+          <p>月額換算のコストや使用終了後の期間を確認することで、次回購入時の判断材料として活用できます。</p>
+        </section>
+      </article>
+    </dialog>
 
     <dialog id="item-name-dialog" class="item-name-dialog">
       <article class="item-name-dialog-card">

--- a/pc-management/README.md
+++ b/pc-management/README.md
@@ -1,81 +1,65 @@
-# 自作PC管理
+# パソコン管理
 
-このフォルダーだけで動く、単体の自作PC管理アプリです。
-
-## 使い方
-
-耐久消費財管理アプリでログインした状態で `index.html` を開いて使います。データは Firestore の `users/{uid}/durableGoodsItems` に保存されます。
-
-以前の localStorage 版で保存したデータがこのブラウザに残っていて、Firestore 側が空の場合は、初回表示時にFirestoreへ移行するか確認します。
+パソコン管理は、パーツ1件をライフサイクル年表の帯1本として管理する画面です。
+データは Firestore の `users/{uid}/durableGoodsItems` に保存しますが、`sourceType: "pcManagement"` で判別し、ライフサイクルコスト側の金額集計や年表には連携しません。
+旧PC単位データは移行せず、`dataVersion: 7` かつ `schemaType: "pcPartLifecycle"` のパーツ単位データだけを表示対象にします。
 
 ## ファイル構成
 
 ```text
 pc-management/
   index.html
-  styles.css
+  form.html
+  hidden.html
   app.js
   README.md
 ```
 
-## 入力方針
+## 入力項目
 
-自作PCは最初から部品単位で購入して組み立てるため、初期購入費をまとめて入力するのではなく、CPU、GPU、マザーボード、メモリ、ストレージ、電源、モニター、OSなどを `parts` として入力します。
+- 商品名（パーツ）
+- 型番
+- 分類（パソコン名: メインPC、サブPC）
+- スペック（詳細入力欄）
+- 購入日
+- 購入価格
+- 使用年数
+- 使用終了日
+- 月額コスト
+- 帯を表示しない
 
-現在スペックは `parts` から自動生成します。同じ種類のパーツが複数ある場合は、購入日が新しいものを現在のパーツとして扱います。GPUは任意です。GPUパーツがない場合は、現在スペックでは「未搭載」と表示します。
+## 年表表示
 
-## データ構造
+通常の `index.html` では、`帯を表示しない` にチェックしていないパーツだけを表示します。
+`hidden.html` では、`帯を表示しない` にチェックしたパーツだけを表示します。
 
-将来、耐久消費財管理アプリへ連携しやすいように、共通化しやすい項目名を含めています。
+帯の色はパソコン名で切り替えます。
+
+- メインPC: 緑系
+- サブPC: 青系
+
+## データ例
 
 ```json
 {
-  "dataVersion": 6,
-  "pcItems": [
-    {
-      "id": "uuid",
-      "category": "pc",
-      "sourceType": "pcManagement",
-      "itemName": "メインPC",
-      "usage": "development",
-      "purchaseDate": "2026-04-21",
-      "price": 250000,
-      "yearsOfUse": 5,
-      "monthlyCost": 4167,
-      "specs": {
-        "cpu": "Ryzen 7 7800X3D",
-        "gpu": "GeForce RTX 4070",
-        "motherboard": "B650",
-        "memory": "32GB",
-        "storage": "NVMe SSD 2TB",
-        "power_supply": "750W Gold",
-        "monitor": "27インチ 144Hz",
-        "os": "Windows 11 Pro"
-      },
-      "parts": [
-        {
-          "id": "uuid",
-          "partType": "cpu",
-          "partName": "Ryzen 7 7800X3D",
-          "purchaseDate": "2026-04-21",
-          "price": 48000,
-          "memo": "初期構成",
-          "createdAt": 1776758400000
-        }
-      ],
-      "createdAt": 1776758400000,
-      "updatedAt": 1776758400000
-    }
-  ]
+  "dataVersion": 7,
+  "schemaType": "pcPartLifecycle",
+  "sourceType": "pcManagement",
+  "category": "pc",
+  "name": "CPU",
+  "itemName": "CPU",
+  "partName": "CPU",
+  "model": "Ryzen 7 7800X3D",
+  "modelNumber": "Ryzen 7 7800X3D",
+  "pcName": "main",
+  "specDetail": "8コア16スレッド",
+  "purchaseDate": "2026-04-21",
+  "price": 48000,
+  "purchasePrice": 48000,
+  "yearsOfUse": 5,
+  "endOfUseDate": "",
+  "hideFromTimeline": false,
+  "monthlyCost": 800,
+  "additionalCosts": []
 }
 ```
-
-## 連携の考え方
-
-- `category`, `itemName`, `purchaseDate`, `price`, `monthlyCost` は耐久消費財管理側へ渡しやすい共通項目です。
-- `parts` はPC専用の部品購入データです。
-- `specs` は `parts` から生成される現在スペックです。
-- 保存先は `users/{uid}/durableGoodsItems/{pcId}` です。
-- Firestoreへは既存フォームと同じトップレベル項目で保存します。
-- PC管理アプリの詳細データは `model` と `additionalCosts.memo` 内のJSONで判別します。
-- `JSON出力` と `JSON読込` で、別環境への移行や将来連携の検証ができます。

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -58,10 +58,8 @@ const elements = {
   summaryCount: document.getElementById("summary-count"),
   summaryTotal: document.getElementById("summary-total"),
   summaryMonthly: document.getElementById("summary-monthly"),
-  authStatus: document.getElementById("auth-status"),
   authError: document.getElementById("auth-error"),
   form: document.getElementById("pc-form"),
-  formMode: document.getElementById("form-mode"),
   formError: document.getElementById("form-error"),
   resetButton: document.getElementById("reset-button"),
   submitButton: document.getElementById("submit-button"),
@@ -76,6 +74,8 @@ const elements = {
   partsDialogClose: document.getElementById("parts-dialog-close"),
   exportButton: document.getElementById("export-button"),
   importFile: document.getElementById("import-file"),
+  calculationTotal: document.getElementById("calculation-total"),
+  calculationMonthlyCost: document.getElementById("calculation-monthly-cost"),
   id: document.getElementById("pc-id"),
   itemName: document.getElementById("item-name"),
   usage: document.getElementById("usage"),
@@ -238,6 +238,16 @@ function calculateMonthlyCost(item) {
   const yearsOfUse = Number(item.yearsOfUse ?? 0);
   if (!Number.isFinite(yearsOfUse) || yearsOfUse <= 0) return 0;
   return calculateTotalInvestment(item) / (yearsOfUse * 12);
+}
+
+function formatMonthlyCost(value) {
+  return `${formatCurrency(value)} /月`;
+}
+
+function parseCurrencyInputValue(value) {
+  const normalizedValue = String(value ?? "").replaceAll(",", "").trim();
+  const amount = Number(normalizedValue);
+  return Number.isFinite(amount) && amount > 0 ? amount : 0;
 }
 
 function normalizePcItem(value) {
@@ -440,12 +450,22 @@ function collectParts() {
       partType,
       partName,
       purchaseDate,
-      price: rawPrice ? Number(rawPrice) : Number.NaN,
+      price: rawPrice ? parseCurrencyInputValue(rawPrice) : Number.NaN,
       memo,
       createdAt: Number(row.dataset.createdAt) || Date.now(),
     });
   }
   return parts;
+}
+
+function updateCalculationResult() {
+  const parts = collectParts();
+  const totalInvestment = calculatePartsTotal(parts);
+  const yearsOfUse = Number(elements.yearsOfUse.value);
+  const monthlyCost = Number.isFinite(yearsOfUse) && yearsOfUse > 0 ? totalInvestment / (yearsOfUse * 12) : 0;
+
+  elements.calculationTotal.textContent = formatCurrency(totalInvestment);
+  elements.calculationMonthlyCost.textContent = formatMonthlyCost(monthlyCost);
 }
 
 function collectPcItem() {
@@ -470,11 +490,11 @@ function resetForm() {
   elements.id.value = "";
   elements.usage.value = "work";
   elements.yearsOfUse.value = "5";
-  elements.formMode.textContent = "現在: 新規登録";
   elements.submitButton.textContent = "登録する";
   elements.cancelButton.hidden = true;
   elements.formError.textContent = "";
   renderPartRows([]);
+  updateCalculationResult();
 }
 
 function fillForm(item) {
@@ -484,11 +504,11 @@ function fillForm(item) {
   elements.usage.value = item.usage;
   elements.purchaseDate.value = item.purchaseDate;
   elements.yearsOfUse.value = item.yearsOfUse;
-  elements.formMode.textContent = "現在: 編集中";
   elements.submitButton.textContent = "更新する";
   elements.cancelButton.hidden = false;
   elements.formError.textContent = "";
   renderPartRows(item.parts);
+  updateCalculationResult();
   window.scrollTo({ top: 0, behavior: "smooth" });
 }
 
@@ -625,6 +645,7 @@ elements.addPartButton.addEventListener("click", () => {
   const row = createPartRow({ createdAt: Date.now() });
   elements.partList.prepend(row);
   row.querySelector(".part-purchase-date").focus();
+  updateCalculationResult();
 });
 
 elements.partList.addEventListener("click", (event) => {
@@ -635,7 +656,14 @@ elements.partList.addEventListener("click", (event) => {
   if (elements.partList.children.length === 0) {
     elements.partList.appendChild(createPartRow({ createdAt: Date.now() }));
   }
+  updateCalculationResult();
 });
+
+elements.form.addEventListener("input", updateCalculationResult);
+elements.form.addEventListener("change", updateCalculationResult);
+elements.yearsOfUse.addEventListener("input", updateCalculationResult);
+elements.partList.addEventListener("input", updateCalculationResult);
+elements.partList.addEventListener("change", updateCalculationResult);
 
 elements.partsDialogClose.addEventListener("click", () => {
   elements.partsDialog.close();
@@ -779,6 +807,7 @@ elements.importFile.addEventListener("change", async () => {
 });
 
 renderPartRows([]);
+updateCalculationResult();
 render();
 
 onAuthChanged(async (user) => {
@@ -788,7 +817,6 @@ onAuthChanged(async (user) => {
   }
 
   state.uid = user.uid;
-  elements.authStatus.textContent = `状態: ログイン中 (${user.email ?? "メール未設定"})`;
   elements.authError.textContent = "";
 
   try {

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -9,7 +9,10 @@ import {
 import {
   db,
   onAuthChanged,
+  decodePcManagementModel,
+  decodePcPartMemo,
   firebaseErrorMessage,
+  pcPartMemoDisplayText,
   registerServiceWorker,
 } from "../js/common.js";
 
@@ -145,25 +148,18 @@ function normalizeLegacySpecs(value) {
 
 function normalizeParts(value) {
   if (!Array.isArray(value)) return [];
-  return value.map((part) => ({
-    id: part?.id || createId(),
-    partType: normalizePartType(part?.partType),
-    partName: String(part?.partName ?? ""),
-    purchaseDate: String(part?.purchaseDate ?? ""),
-    price: Number(part?.price ?? 0),
-    memo: String(part?.memo ?? ""),
-    createdAt: Number.isFinite(Number(part?.createdAt)) ? Number(part.createdAt) : Date.now(),
-  }));
-}
-
-function parsePrefixedJson(value, prefix) {
-  const text = String(value ?? "");
-  if (!text.startsWith(prefix)) return null;
-  try {
-    return JSON.parse(text.slice(prefix.length));
-  } catch (_error) {
-    return null;
-  }
+  return value.map((part) => {
+    const decodedMemo = decodePcPartMemo(part?.memo);
+    return {
+      id: part?.id || createId(),
+      partType: normalizePartType(decodedMemo?.partType ?? part?.partType),
+      partName: String(decodedMemo?.partName ?? part?.partName ?? ""),
+      purchaseDate: String(decodedMemo?.purchaseDate ?? part?.purchaseDate ?? ""),
+      price: Number(part?.price ?? 0),
+      memo: String(decodedMemo?.memo ?? part?.memo ?? ""),
+      createdAt: Number.isFinite(Number(part?.createdAt)) ? Number(part.createdAt) : Date.now(),
+    };
+  });
 }
 
 function encodePcModel(item) {
@@ -177,7 +173,7 @@ function encodePcModel(item) {
 }
 
 function decodePcModel(value) {
-  return parsePrefixedJson(value, PC_MODEL_PREFIX);
+  return decodePcManagementModel(value);
 }
 
 function encodePartMemo(part) {
@@ -193,7 +189,7 @@ function decodePartsFromAdditionalCosts(value) {
   if (!Array.isArray(value)) return [];
   return value
     .map((cost) => {
-      const decoded = parsePrefixedJson(cost?.memo, PART_MEMO_PREFIX);
+      const decoded = decodePcPartMemo(cost?.memo);
       if (!decoded) return null;
       return {
         id: cost?.id || createId(),
@@ -404,16 +400,17 @@ function validatePcItem(item) {
 }
 
 function createPartRow(part = {}) {
+  const decodedMemo = decodePcPartMemo(part.memo);
   const fragment = elements.partRowTemplate.content.cloneNode(true);
   const row = fragment.querySelector(".part-row");
   row.dataset.id = part.id || createId();
   row.dataset.createdAt = Number.isFinite(Number(part.createdAt)) ? String(part.createdAt) : String(Date.now());
-  row.querySelector(".part-type").value = normalizePartType(part.partType);
-  row.querySelector(".part-purchase-date").value = part.purchaseDate ?? "";
-  row.querySelector(".part-name").value = part.partName ?? "";
+  row.querySelector(".part-type").value = normalizePartType(decodedMemo?.partType ?? part.partType);
+  row.querySelector(".part-purchase-date").value = decodedMemo?.purchaseDate ?? part.purchaseDate ?? "";
+  row.querySelector(".part-name").value = decodedMemo?.partName ?? part.partName ?? "";
   row.querySelector(".part-price").value =
     Number.isFinite(Number(part.price)) && Number(part.price) >= 0 ? part.price : "";
-  row.querySelector(".part-memo").value = part.memo ?? "";
+  row.querySelector(".part-memo").value = decodedMemo?.memo ?? pcPartMemoDisplayText(part.memo);
   return row;
 }
 
@@ -514,11 +511,11 @@ function renderParts(parts) {
         .map(
           (part) => `
             <div class="history-row">
-              <span>${escapeHtml(part.purchaseDate)}</span>
-              <span>${escapeHtml(partTypeLabels[part.partType] ?? "その他")}</span>
-              <strong>${escapeHtml(part.partName)}</strong>
-              <span>${formatCurrency(part.price)}</span>
-              <span>${escapeHtml(part.memo)}</span>
+              <span data-label="購入日">${escapeHtml(part.purchaseDate)}</span>
+              <span data-label="種別">${escapeHtml(partTypeLabels[part.partType] ?? "その他")}</span>
+              <strong data-label="パーツ名">${escapeHtml(part.partName)}</strong>
+              <span data-label="費用">${formatCurrency(part.price)}</span>
+              <span data-label="メモ">${escapeHtml(part.memo)}</span>
             </div>
           `
         )

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -9,85 +9,72 @@ import {
 import {
   db,
   onAuthChanged,
-  decodePcManagementModel,
-  decodePcPartMemo,
   firebaseErrorMessage,
-  pcPartMemoDisplayText,
   registerServiceWorker,
 } from "../js/common.js";
 
-const LOCAL_STORAGE_KEY = "pcManagementItems.v1";
 const PC_ITEMS_COLLECTION = "durableGoodsItems";
 const SOURCE_TYPE = "pcManagement";
-const DATA_VERSION = 6;
-const PC_MODEL_PREFIX = "[pcManagement]";
-const PART_MEMO_PREFIX = "[pcPart]";
+const DATA_VERSION = 7;
+const SCHEMA_TYPE = "pcPartLifecycle";
+const TIMELINE_MIN_YEAR = 2015;
+const TIMELINE_MAX_YEAR = 2055;
+const DESKTOP_YEAR_WIDTH = 168;
+const DESKTOP_LABEL_WIDTH = 230;
+const MOBILE_YEAR_WIDTH = 28;
+const MOBILE_LABEL_WIDTH = 72;
+const TIMELINE_MODE = document.body.dataset.timelineMode || "visible";
 
-const usageLabels = {
-  work: "仕事",
-  game: "ゲーム",
-  development: "開発",
-  other: "その他",
+const pcNameLabels = {
+  main: "メインPC",
+  sub: "サブPC",
 };
-
-const partTypeLabels = {
-  cpu: "CPU",
-  gpu: "GPU",
-  motherboard: "マザーボード",
-  memory: "メモリ",
-  storage: "ストレージ",
-  power_supply: "電源",
-  monitor: "モニター",
-  os: "OS",
-  other: "その他",
-};
-
-const currentSpecTypes = [
-  "cpu",
-  "gpu",
-  "motherboard",
-  "memory",
-  "storage",
-  "power_supply",
-  "monitor",
-  "os",
-];
-const requiredSpecTypes = currentSpecTypes.filter((specType) => specType !== "gpu");
 
 const elements = {
   summaryCount: document.getElementById("summary-count"),
   summaryTotal: document.getElementById("summary-total"),
   summaryMonthly: document.getElementById("summary-monthly"),
   authError: document.getElementById("auth-error"),
+  createButton: document.getElementById("create-button"),
+  hiddenButton: document.getElementById("hidden-button"),
+  backButton: document.getElementById("back-button"),
+  helpButton: document.getElementById("help-button"),
+  helpDialog: document.getElementById("help-dialog"),
+  helpCloseButton: document.getElementById("help-close-button"),
+  toListButton: document.getElementById("to-list-button"),
+  formPanel: document.getElementById("form-panel"),
   form: document.getElementById("pc-form"),
   formError: document.getElementById("form-error"),
   resetButton: document.getElementById("reset-button"),
   submitButton: document.getElementById("submit-button"),
   cancelButton: document.getElementById("cancel-button"),
-  pcList: document.getElementById("pc-list"),
-  addPartButton: document.getElementById("add-part-button"),
-  partList: document.getElementById("part-list"),
-  partRowTemplate: document.getElementById("part-row-template"),
-  partsDialog: document.getElementById("parts-dialog"),
-  partsDialogTitle: document.getElementById("parts-dialog-title"),
-  partsDialogBody: document.getElementById("parts-dialog-body"),
-  partsDialogClose: document.getElementById("parts-dialog-close"),
-  exportButton: document.getElementById("export-button"),
-  importFile: document.getElementById("import-file"),
+  itemList: document.getElementById("item-list"),
   calculationTotal: document.getElementById("calculation-total"),
   calculationMonthlyCost: document.getElementById("calculation-monthly-cost"),
   id: document.getElementById("pc-id"),
-  itemName: document.getElementById("item-name"),
-  usage: document.getElementById("usage"),
+  partName: document.getElementById("part-name"),
+  modelNumber: document.getElementById("model-number"),
+  pcName: document.getElementById("pc-name"),
+  specDetail: document.getElementById("spec-detail"),
   purchaseDate: document.getElementById("purchase-date"),
+  purchasePrice: document.getElementById("purchase-price"),
   yearsOfUse: document.getElementById("years-of-use"),
+  endOfUseDate: document.getElementById("end-of-use-date"),
   hideFromTimeline: document.getElementById("hide-from-timeline"),
+  itemDialog: document.getElementById("item-dialog"),
+  dialogItemName: document.getElementById("dialog-item-name"),
+  dialogItemMeta: document.getElementById("dialog-item-meta"),
+  dialogEditButton: document.getElementById("dialog-edit-button"),
+  dialogDeleteButton: document.getElementById("dialog-delete-button"),
+  dialogCloseButton: document.getElementById("dialog-close-button"),
 };
 
 const state = {
   uid: null,
   items: [],
+  selectedItemId: null,
   editingId: new URLSearchParams(window.location.search).get("id"),
+  resizeTimer: null,
 };
 
 function createId() {
@@ -95,6 +82,13 @@ function createId() {
     return crypto.randomUUID();
   }
   return `${Date.now()}-${Math.floor(Math.random() * 100000)}`;
+}
+
+function createElement(tagName, className, textContent = "") {
+  const element = document.createElement(tagName);
+  if (className) element.className = className;
+  if (textContent) element.textContent = textContent;
+  return element;
 }
 
 function formatCurrency(value) {
@@ -105,21 +99,10 @@ function formatCurrency(value) {
   }).format(Number(value) || 0);
 }
 
-function escapeHtml(value) {
-  return String(value)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function normalizeUsage(value) {
-  return usageLabels[value] ? value : "other";
-}
-
-function normalizePartType(value) {
-  return partTypeLabels[value] ? value : "other";
+function parseCurrencyInputValue(value) {
+  const normalizedValue = String(value ?? "").replaceAll(",", "").trim();
+  const amount = Number(normalizedValue);
+  return Number.isFinite(amount) && amount >= 0 ? amount : Number.NaN;
 }
 
 function toMillis(value, fallback = Date.now()) {
@@ -133,146 +116,68 @@ function toMillis(value, fallback = Date.now()) {
   return Number.isFinite(numericValue) ? numericValue : fallback;
 }
 
-function normalizeLegacySpecs(value) {
-  const specs = value && typeof value === "object" ? value : {};
-  return {
-    cpu: String(specs.cpu ?? ""),
-    gpu: String(specs.gpu ?? ""),
-    motherboard: String(specs.motherboard ?? ""),
-    memory: String(specs.memory ?? ""),
-    storage: String(specs.storage ?? ""),
-    power_supply: String(specs.powerSupply ?? specs.power_supply ?? ""),
-    monitor: String(specs.monitor ?? ""),
-    os: String(specs.os ?? ""),
-  };
+function parseDate(value) {
+  if (!value) return null;
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
-function normalizeParts(value) {
-  if (!Array.isArray(value)) return [];
-  return value.map((part) => {
-    const decodedMemo = decodePcPartMemo(part?.memo);
-    return {
-      id: part?.id || createId(),
-      partType: normalizePartType(decodedMemo?.partType ?? part?.partType),
-      partName: String(decodedMemo?.partName ?? part?.partName ?? ""),
-      purchaseDate: String(decodedMemo?.purchaseDate ?? part?.purchaseDate ?? ""),
-      price: Number(part?.price ?? 0),
-      memo: String(decodedMemo?.memo ?? part?.memo ?? ""),
-      createdAt: Number.isFinite(Number(part?.createdAt)) ? Number(part.createdAt) : Date.now(),
-    };
-  });
+function toMonthIndex(date) {
+  return date.getFullYear() * 12 + date.getMonth();
 }
 
-function encodePcModel(item) {
-  return `${PC_MODEL_PREFIX}${JSON.stringify({
-    dataVersion: DATA_VERSION,
-    itemName: item.itemName,
-    usage: item.usage,
-    specs: item.specs,
-    parts: item.parts,
-  })}`;
+function daysInMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
 }
 
-function decodePcModel(value) {
-  return decodePcManagementModel(value);
+function toMonthPosition(date) {
+  return toMonthIndex(date) + (date.getDate() - 1) / daysInMonth(date);
 }
 
-function encodePartMemo(part) {
-  return `${PART_MEMO_PREFIX}${JSON.stringify({
-    partType: part.partType,
-    partName: part.partName,
-    purchaseDate: part.purchaseDate,
-    memo: part.memo,
-  })}`;
+function addYearsClamped(date, years) {
+  const targetYear = date.getFullYear() + years;
+  const targetMonth = date.getMonth();
+  const targetDay = Math.min(date.getDate(), new Date(targetYear, targetMonth + 1, 0).getDate());
+  return new Date(targetYear, targetMonth, targetDay);
 }
 
-function decodePartsFromAdditionalCosts(value) {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((cost) => {
-      const decoded = decodePcPartMemo(cost?.memo);
-      if (!decoded) return null;
-      return {
-        id: cost?.id || createId(),
-        partType: normalizePartType(decoded.partType),
-        partName: String(decoded.partName ?? ""),
-        purchaseDate: String(decoded.purchaseDate ?? ""),
-        price: Number(cost?.amount ?? 0),
-        memo: String(decoded.memo ?? ""),
-        createdAt: Number.isFinite(Number(cost?.createdAt)) ? Number(cost.createdAt) : Date.now(),
-      };
-    })
-    .filter(Boolean);
-}
-
-function sortParts(parts) {
-  return normalizeParts(parts).sort((a, b) => {
-    const dateCompare = String(b.purchaseDate).localeCompare(String(a.purchaseDate));
-    if (dateCompare !== 0) return dateCompare;
-    return Number(b.createdAt ?? 0) - Number(a.createdAt ?? 0);
-  });
-}
-
-function deriveCurrentSpecs(parts, legacySpecs = {}) {
-  const specs = normalizeLegacySpecs(legacySpecs);
-  for (const part of sortParts(parts).reverse()) {
-    if (!currentSpecTypes.includes(part.partType)) continue;
-    if (!part.partName.trim()) continue;
-    specs[part.partType] = part.partName;
-  }
-  return specs;
-}
-
-function calculatePartsTotal(parts) {
-  return normalizeParts(parts).reduce((total, part) => {
-    if (!Number.isFinite(part.price)) return total;
-    return total + part.price;
-  }, 0);
-}
-
-function calculateTotalInvestment(item) {
-  const partsTotal = calculatePartsTotal(item.parts);
-  return item.parts.length > 0 ? partsTotal : Number(item.price ?? 0);
-}
-
-function calculateMonthlyCost(item) {
-  const yearsOfUse = Number(item.yearsOfUse ?? 0);
-  if (!Number.isFinite(yearsOfUse) || yearsOfUse <= 0) return 0;
-  return calculateTotalInvestment(item) / (yearsOfUse * 12);
+function formatYearMonthFromIndex(monthIndex) {
+  const normalizedMonthIndex = Math.floor(monthIndex);
+  const year = Math.floor(normalizedMonthIndex / 12);
+  const month = (normalizedMonthIndex % 12) + 1;
+  return `${year}/${String(month).padStart(2, "0")}`;
 }
 
 function formatMonthlyCost(value) {
   return `${formatCurrency(value)} /月`;
 }
 
-function parseCurrencyInputValue(value) {
-  const normalizedValue = String(value ?? "").replaceAll(",", "").trim();
-  const amount = Number(normalizedValue);
-  return Number.isFinite(amount) && amount > 0 ? amount : 0;
+function calculateMonthlyCost(item) {
+  const purchasePrice = Number(item.purchasePrice ?? 0);
+  const yearsOfUse = Number(item.yearsOfUse ?? 0);
+  if (!Number.isFinite(purchasePrice) || !Number.isFinite(yearsOfUse) || yearsOfUse <= 0) return 0;
+  return purchasePrice / (yearsOfUse * 12);
 }
 
-function normalizePcItem(value) {
+function normalizePcName(value) {
+  return pcNameLabels[value] ? value : "main";
+}
+
+function normalizePcPartItem(value) {
   const item = value && typeof value === "object" ? value : {};
-  const decodedModel = decodePcModel(item.model);
-  const parts = normalizeParts(
-    item.parts ??
-      item.upgradeHistory ??
-      decodedModel?.parts ??
-      decodePartsFromAdditionalCosts(item.additionalCosts)
-  );
-  const legacySpecs = normalizeLegacySpecs(item.specs ?? decodedModel?.specs);
-  const fallbackPrice = Number(item.price ?? item.purchasePrice ?? item.initialPurchaseCost ?? 0);
+  const purchasePrice = Number(item.purchasePrice ?? item.price ?? 0);
   const normalized = {
     id: item.id || createId(),
-    category: "pc",
-    itemName: String(item.itemName ?? decodedModel?.itemName ?? item.name ?? ""),
-    usage: normalizeUsage(item.usage ?? decodedModel?.usage),
+    sourceType: SOURCE_TYPE,
+    partName: String(item.partName ?? item.name ?? item.itemName ?? ""),
+    modelNumber: String(item.modelNumber ?? item.model ?? ""),
+    pcName: normalizePcName(item.pcName),
+    specDetail: String(item.specDetail ?? ""),
     purchaseDate: String(item.purchaseDate ?? ""),
-    price: parts.length > 0 ? calculatePartsTotal(parts) : fallbackPrice,
+    purchasePrice: Number.isFinite(purchasePrice) ? purchasePrice : 0,
     yearsOfUse: Number(item.yearsOfUse ?? 5),
+    endOfUseDate: String(item.endOfUseDate ?? ""),
     hideFromTimeline: Boolean(item.hideFromTimeline),
-    specs: deriveCurrentSpecs(parts, legacySpecs),
-    parts,
     createdAt: toMillis(item.createdAt),
     updatedAt: toMillis(item.updatedAt),
   };
@@ -291,30 +196,27 @@ function pcItemDocRef(uid, itemId) {
 }
 
 function toFirestorePayload(item) {
-  const normalized = normalizePcItem(item);
-  const totalInvestment = calculateTotalInvestment(normalized);
+  const normalized = normalizePcPartItem(item);
   return {
+    dataVersion: DATA_VERSION,
+    schemaType: SCHEMA_TYPE,
     sourceType: SOURCE_TYPE,
-    name: normalized.itemName,
-    model: encodePcModel(normalized),
     category: "pc",
-    itemName: normalized.itemName,
-    usage: normalized.usage,
+    name: normalized.partName,
+    itemName: normalized.partName,
+    partName: normalized.partName,
+    model: normalized.modelNumber,
+    modelNumber: normalized.modelNumber,
+    pcName: normalized.pcName,
+    specDetail: normalized.specDetail,
     purchaseDate: normalized.purchaseDate,
-    price: totalInvestment,
-    purchasePrice: totalInvestment,
+    price: normalized.purchasePrice,
+    purchasePrice: normalized.purchasePrice,
     yearsOfUse: normalized.yearsOfUse,
-    hideFromTimeline: Boolean(normalized.hideFromTimeline),
+    endOfUseDate: normalized.endOfUseDate,
+    hideFromTimeline: normalized.hideFromTimeline,
     monthlyCost: calculateMonthlyCost(normalized),
-    specs: normalized.specs,
-    parts: normalized.parts,
-    endOfUseDate: "",
-    additionalCosts: normalized.parts.map((part) => ({
-      id: part.id,
-      amount: Number(part.price ?? 0),
-      memo: encodePartMemo(part),
-      createdAt: Number.isFinite(Number(part.createdAt)) ? Number(part.createdAt) : Date.now(),
-    })),
+    additionalCosts: [],
     createdAt: normalized.createdAt,
     updatedAt: serverTimestamp(),
   };
@@ -325,8 +227,10 @@ async function loadFirestoreItems(uid) {
   const items = [];
   snapshot.forEach((documentSnapshot) => {
     const data = documentSnapshot.data();
-    if (data.sourceType !== SOURCE_TYPE && !decodePcModel(data.model)) return;
-    items.push(normalizePcItem({
+    if (data.sourceType !== SOURCE_TYPE) return;
+    if (Number(data.dataVersion ?? 0) !== DATA_VERSION) return;
+    if (data.schemaType !== SCHEMA_TYPE) return;
+    items.push(normalizePcPartItem({
       id: documentSnapshot.id,
       ...data,
     }));
@@ -335,7 +239,7 @@ async function loadFirestoreItems(uid) {
 }
 
 async function saveFirestoreItem(uid, item) {
-  const normalized = normalizePcItem(item);
+  const normalized = normalizePcPartItem(item);
   await setDoc(pcItemDocRef(uid, normalized.id), toFirestorePayload(normalized));
 }
 
@@ -343,481 +247,525 @@ async function removeFirestoreItem(uid, itemId) {
   await deleteDoc(pcItemDocRef(uid, itemId));
 }
 
-async function replaceFirestoreItems(uid, items) {
-  await Promise.all(state.items.map((item) => removeFirestoreItem(uid, item.id)));
-  await Promise.all(items.map((item) => saveFirestoreItem(uid, item)));
-}
-
-function loadLocalItemsForMigration() {
-  try {
-    const rawValue = localStorage.getItem(LOCAL_STORAGE_KEY);
-    if (!rawValue) return [];
-    const parsed = JSON.parse(rawValue);
-    const items = Array.isArray(parsed) ? parsed : parsed.pcItems;
-    return Array.isArray(items) ? items.map(normalizePcItem) : [];
-  } catch (_error) {
-    return [];
-  }
-}
-
-function saveLocalBackupItems(items) {
-  const payload = {
-    dataVersion: DATA_VERSION,
-    pcItems: items.map(normalizePcItem),
-  };
-  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(payload));
-}
-
-async function migrateLocalItemsIfNeeded(uid) {
-  if (state.items.length > 0) return;
-  const localItems = loadLocalItemsForMigration();
-  if (localItems.length === 0) return;
-  const shouldMigrate = confirm("このブラウザに保存済みのPCデータがあります。Firestoreへ移行しますか？");
-  if (!shouldMigrate) return;
-  await Promise.all(localItems.map((item) => saveFirestoreItem(uid, item)));
-  localStorage.removeItem(LOCAL_STORAGE_KEY);
-  state.items = await loadFirestoreItems(uid);
-  render();
-}
-
 function sortItems(items) {
   return [...items].sort((a, b) => {
+    const pcCompare = String(a.pcName).localeCompare(String(b.pcName));
+    if (pcCompare !== 0) return pcCompare;
     const dateCompare = String(b.purchaseDate).localeCompare(String(a.purchaseDate));
     if (dateCompare !== 0) return dateCompare;
-    return Number(b.updatedAt ?? 0) - Number(a.updatedAt ?? 0);
+    return String(a.partName).localeCompare(String(b.partName), "ja");
   });
 }
 
+function visibleItems() {
+  return state.items.filter((item) =>
+    TIMELINE_MODE === "hidden" ? item.hideFromTimeline : !item.hideFromTimeline
+  );
+}
+
+function itemStartMonth(item) {
+  const purchaseDate = parseDate(item.purchaseDate);
+  return purchaseDate ? toMonthPosition(purchaseDate) : TIMELINE_MIN_YEAR * 12;
+}
+
+function currentMonthIndex() {
+  return toMonthPosition(new Date());
+}
+
+function itemPlannedEndMonth(item) {
+  const purchaseDate = parseDate(item.purchaseDate);
+  const yearsOfUse = Math.max(Number(item.yearsOfUse) || 1, 1);
+  if (!purchaseDate) return itemStartMonth(item) + yearsOfUse * 12;
+  return toMonthPosition(addYearsClamped(purchaseDate, yearsOfUse));
+}
+
+function itemActualEndMonth(item) {
+  const endOfUseDate = parseDate(item.endOfUseDate);
+  if (endOfUseDate) return Math.max(itemStartMonth(item), toMonthPosition(endOfUseDate));
+  return currentMonthIndex();
+}
+
+function itemEndMonth(item) {
+  if (item.endOfUseDate) return itemActualEndMonth(item);
+  return Math.max(itemPlannedEndMonth(item), itemActualEndMonth(item));
+}
+
+function itemUnusedPeriodEndMonth(item) {
+  if (!item.endOfUseDate) return itemEndMonth(item);
+  return itemPlannedEndMonth(item);
+}
+
+function itemTimelineEndMonth(item) {
+  if (item.endOfUseDate) return Math.max(itemEndMonth(item), itemUnusedPeriodEndMonth(item));
+  return itemEndMonth(item);
+}
+
+function itemEndLabel(item, endMonth) {
+  if (item.endOfUseDate) return `${formatYearMonthFromIndex(endMonth)} (使用終了)`;
+  return `${formatYearMonthFromIndex(endMonth)} (${item.yearsOfUse}年)`;
+}
+
+function calculateLifecycleProgress(item) {
+  const startMonth = itemStartMonth(item);
+  const durationMonths = Math.max(itemPlannedEndMonth(item) - startMonth, 1);
+  return (currentMonthIndex() - startMonth) / durationMonths;
+}
+
+function lifecycleStatus(item) {
+  if (item.endOfUseDate) return "ended";
+  const progress = calculateLifecycleProgress(item);
+  if (progress >= 1) return "ended";
+  if (progress >= 0.85) return "danger";
+  if (progress >= 0.5) return "warning";
+  return "normal";
+}
+
+function pcNameClass(item) {
+  return item.pcName === "sub" ? "category-pc-sub" : "category-pc-main";
+}
+
+function timelineLayout() {
+  const isCompact = window.matchMedia("(max-width: 640px)").matches;
+  return {
+    isCompact,
+    labelWidth: isCompact ? MOBILE_LABEL_WIDTH : DESKTOP_LABEL_WIDTH,
+    yearWidth: isCompact ? MOBILE_YEAR_WIDTH : DESKTOP_YEAR_WIDTH,
+  };
+}
+
+function resolveTimelineRange(items) {
+  let minYear = TIMELINE_MIN_YEAR;
+  let maxYear = TIMELINE_MAX_YEAR;
+  for (const item of items) {
+    minYear = Math.min(minYear, Math.floor(itemStartMonth(item) / 12));
+    maxYear = Math.max(maxYear, Math.ceil(itemTimelineEndMonth(item) / 12));
+  }
+  return { minYear, maxYear };
+}
+
+function currentLinePosition(minYear, maxYear) {
+  const { labelWidth, yearWidth } = timelineLayout();
+  const minMonth = minYear * 12;
+  const maxMonth = maxYear * 12;
+  const nowPosition = currentMonthIndex();
+  if (nowPosition < minMonth || nowPosition > maxMonth) return null;
+  return labelWidth + ((nowPosition - minMonth) / 12) * yearWidth;
+}
+
+function renderAxis(grid, minYear, maxYear, positionClass) {
+  const { isCompact, labelWidth, yearWidth } = timelineLayout();
+  const axis = createElement("div", `timeline-axis ${positionClass}`);
+  const yearCount = maxYear - minYear;
+
+  for (let year = minYear; year <= maxYear; year += 1) {
+    if (isCompact && year % 5 !== 0) continue;
+    const marker = createElement("span", "timeline-year", String(year));
+    marker.style.left = `${labelWidth + (year - minYear) * yearWidth}px`;
+    axis.appendChild(marker);
+  }
+
+  for (let index = 0; index <= yearCount * 12; index += 1) {
+    const tick = createElement("span", index % 12 === 0 ? "timeline-tick major" : "timeline-tick");
+    tick.style.left = `${labelWidth + (index / 12) * yearWidth}px`;
+    axis.appendChild(tick);
+  }
+
+  grid.appendChild(axis);
+}
+
+function renderCurrentLine(grid, minYear, maxYear) {
+  const currentPosition = currentLinePosition(minYear, maxYear);
+  if (currentPosition === null) return;
+  const currentLine = createElement("div", "timeline-current-line");
+  currentLine.style.left = `${currentPosition}px`;
+  currentLine.innerHTML = "<span>現在</span>";
+  grid.appendChild(currentLine);
+}
+
+function centerCurrentLine(scroll, minYear, maxYear) {
+  const currentPosition = currentLinePosition(minYear, maxYear);
+  if (currentPosition === null) return;
+  const { labelWidth } = timelineLayout();
+  requestAnimationFrame(() => {
+    const maxScrollLeft = Math.max(scroll.scrollWidth - scroll.clientWidth, 0);
+    const visibleTimelineWidth = Math.max(scroll.clientWidth - labelWidth, 1);
+    const targetScrollLeft = currentPosition - labelWidth - visibleTimelineWidth / 2;
+    scroll.scrollLeft = Math.min(Math.max(targetScrollLeft, 0), maxScrollLeft);
+  });
+}
+
+function renderEmptyTimeline() {
+  if (!elements.itemList) return;
+  elements.itemList.innerHTML = "";
+  const empty = createElement("div", "timeline-empty");
+  const message =
+    TIMELINE_MODE === "hidden"
+      ? "帯を表示しないパーツはありません。"
+      : "パーツを登録すると、購入日から使用年数までのライフサイクル帯を表示します。";
+  empty.innerHTML = `
+    <strong>登録データがありません</strong>
+    <span></span>
+  `;
+  empty.querySelector("span").textContent = message;
+  elements.itemList.appendChild(empty);
+}
+
+function renderTimeline() {
+  if (!elements.itemList) return;
+  const items = sortItems(visibleItems());
+  elements.itemList.innerHTML = "";
+  if (items.length === 0) {
+    renderEmptyTimeline();
+    return;
+  }
+
+  const { minYear, maxYear } = resolveTimelineRange(items);
+  const { labelWidth, yearWidth } = timelineLayout();
+  const timelineWidth = labelWidth + (maxYear - minYear) * yearWidth;
+  const minMonth = minYear * 12;
+
+  const scroll = createElement("div", "timeline-scroll");
+  scroll.tabIndex = 0;
+  scroll.setAttribute("aria-label", "ライフサイクル年表。横にスクロールできます。");
+
+  const grid = createElement("div", "timeline-grid");
+  grid.style.width = `${timelineWidth}px`;
+  grid.style.setProperty("--label-width", `${labelWidth}px`);
+  grid.style.setProperty("--year-width", `${yearWidth}px`);
+
+  renderAxis(grid, minYear, maxYear, "timeline-axis-top");
+  renderCurrentLine(grid, minYear, maxYear);
+
+  const rows = createElement("div", "timeline-rows");
+  for (const item of items) {
+    const startMonth = itemStartMonth(item);
+    const endMonth = itemEndMonth(item);
+    const unusedPeriodEndMonth = itemUnusedPeriodEndMonth(item);
+    const plannedEndMonth = itemPlannedEndMonth(item);
+    const status = lifecycleStatus(item);
+    const left = labelWidth + ((startMonth - minMonth) / 12) * yearWidth;
+    const width = Math.max(((endMonth - startMonth) / 12) * yearWidth, timelineLayout().isCompact ? 32 : 84);
+    const unusedPeriodLeft = labelWidth + ((endMonth - minMonth) / 12) * yearWidth;
+    const unusedPeriodWidth = ((unusedPeriodEndMonth - endMonth) / 12) * yearWidth;
+    const overuseStartPercent = ((plannedEndMonth - startMonth) / Math.max(endMonth - startMonth, 1)) * 100;
+    const isOverused = itemActualEndMonth(item) > plannedEndMonth;
+    const isSelected = item.id === state.selectedItemId;
+    const colorClass = pcNameClass(item);
+
+    const row = createElement("div", "timeline-row");
+    const label = createElement("div", "timeline-row-label");
+    label.innerHTML = `<span class="category-swatch ${colorClass}"></span><strong></strong>`;
+    label.querySelector("strong").textContent = pcNameLabels[item.pcName] || "メインPC";
+
+    const band = createElement("button", `lifecycle-band ${colorClass}${isOverused ? " overused" : ""}`);
+    band.type = "button";
+    band.dataset.id = item.id;
+    band.setAttribute("aria-pressed", String(isSelected));
+    band.setAttribute("aria-label", `${item.partName || "パーツ"}の詳細を表示`);
+    band.style.left = `${left}px`;
+    band.style.width = `${width}px`;
+    if (isOverused) {
+      band.style.setProperty("--overuse-start", `${Math.min(Math.max(overuseStartPercent, 0), 100)}%`);
+    }
+
+    band.append(
+      createElement("span", "band-name", item.partName || "商品名未入力"),
+      createElement("span", "band-cost", formatMonthlyCost(calculateMonthlyCost(item)))
+    );
+
+    if (item.endOfUseDate && unusedPeriodWidth > 0) {
+      const postEndBand = createElement("button", "post-end-band");
+      postEndBand.type = "button";
+      postEndBand.dataset.id = item.id;
+      postEndBand.setAttribute("aria-pressed", String(isSelected));
+      postEndBand.setAttribute("aria-label", `${item.partName || "パーツ"}の使わなかった期間`);
+      postEndBand.style.left = `${unusedPeriodLeft}px`;
+      postEndBand.style.width = `${Math.max(unusedPeriodWidth, 2)}px`;
+      row.appendChild(postEndBand);
+    }
+
+    const endLabel = createElement("span", `timeline-end-label status-${status}`, itemEndLabel(item, endMonth));
+    endLabel.style.left = `${left + width + 10}px`;
+
+    row.append(label, band, endLabel);
+    rows.appendChild(row);
+  }
+
+  grid.appendChild(rows);
+  renderAxis(grid, minYear, maxYear, "timeline-axis-bottom");
+  scroll.appendChild(grid);
+  elements.itemList.appendChild(scroll);
+  centerCurrentLine(scroll, minYear, maxYear);
+}
+
+function renderSummary() {
+  if (!elements.summaryCount || !elements.summaryTotal || !elements.summaryMonthly) return;
+  const items = visibleItems();
+  const activeItems = items.filter((item) => !item.endOfUseDate);
+  const purchaseTotal = activeItems.reduce((total, item) => total + Number(item.purchasePrice || 0), 0);
+  const monthlyCostTotal = activeItems.reduce((total, item) => total + calculateMonthlyCost(item), 0);
+  elements.summaryCount.textContent = `${items.length} 件`;
+  elements.summaryTotal.textContent = formatCurrency(purchaseTotal);
+  elements.summaryMonthly.textContent = formatMonthlyCost(monthlyCostTotal);
+}
+
+function render() {
+  renderSummary();
+  renderTimeline();
+}
+
 function validatePcItem(item) {
-  if (!item.itemName.trim()) return "PC名を入力してください。";
-  if (!item.purchaseDate) return "組立日を入力してください。";
-  if (!Number.isFinite(item.yearsOfUse) || item.yearsOfUse <= 0) {
-    return "想定使用年数は1年以上で入力してください。";
-  }
-  if (item.parts.length === 0) return "パーツを1件以上入力してください。";
-
-  for (const part of item.parts) {
-    if (!part.partName.trim()) return "パーツ名を入力してください。";
-    if (!part.purchaseDate) return "パーツの購入日を入力してください。";
-    if (!Number.isFinite(part.price) || part.price < 0) {
-      return "パーツ費用は0以上で入力してください。";
-    }
-  }
-
-  for (const specType of requiredSpecTypes) {
-    if (!item.specs[specType].trim()) {
-      return `${partTypeLabels[specType]}をパーツ入力に追加してください。`;
-    }
+  if (!item.partName.trim()) return "商品名（パーツ）を入力してください。";
+  if (!item.modelNumber.trim()) return "型番を入力してください。";
+  if (!pcNameLabels[item.pcName]) return "分類（パソコン名）を選択してください。";
+  if (!item.purchaseDate) return "購入日を入力してください。";
+  if (!Number.isFinite(item.purchasePrice) || item.purchasePrice < 0) return "購入価格は0以上で入力してください。";
+  if (!Number.isFinite(item.yearsOfUse) || item.yearsOfUse <= 0) return "使用年数は1以上で入力してください。";
+  if (item.endOfUseDate && item.endOfUseDate < item.purchaseDate) {
+    return "使用終了日は購入日以降の日付を入力してください。";
   }
   return null;
 }
 
-function createPartRow(part = {}) {
-  const decodedMemo = decodePcPartMemo(part.memo);
-  const fragment = elements.partRowTemplate.content.cloneNode(true);
-  const row = fragment.querySelector(".part-row");
-  row.dataset.id = part.id || createId();
-  row.dataset.createdAt = Number.isFinite(Number(part.createdAt)) ? String(part.createdAt) : String(Date.now());
-  row.querySelector(".part-type").value = normalizePartType(decodedMemo?.partType ?? part.partType);
-  row.querySelector(".part-purchase-date").value = decodedMemo?.purchaseDate ?? part.purchaseDate ?? "";
-  row.querySelector(".part-name").value = decodedMemo?.partName ?? part.partName ?? "";
-  row.querySelector(".part-price").value =
-    Number.isFinite(Number(part.price)) && Number(part.price) >= 0 ? part.price : "";
-  row.querySelector(".part-memo").value = decodedMemo?.memo ?? pcPartMemoDisplayText(part.memo);
-  return row;
-}
-
-function renderPartRows(parts) {
-  elements.partList.innerHTML = "";
-  for (const part of sortParts(parts)) {
-    elements.partList.appendChild(createPartRow(part));
-  }
-  if (elements.partList.children.length === 0) {
-    elements.partList.appendChild(createPartRow({ createdAt: Date.now() }));
-  }
-}
-
-function collectParts() {
-  const rows = elements.partList.querySelectorAll(".part-row");
-  const parts = [];
-  for (const row of rows) {
-    const partType = row.querySelector(".part-type").value;
-    const purchaseDate = row.querySelector(".part-purchase-date").value;
-    const partName = row.querySelector(".part-name").value.trim();
-    const rawPrice = row.querySelector(".part-price").value.trim();
-    const memo = row.querySelector(".part-memo").value.trim();
-    if (!partName && !purchaseDate && !rawPrice && !memo) continue;
-
-    parts.push({
-      id: row.dataset.id || createId(),
-      partType,
-      partName,
-      purchaseDate,
-      price: rawPrice ? parseCurrencyInputValue(rawPrice) : Number.NaN,
-      memo,
-      createdAt: Number(row.dataset.createdAt) || Date.now(),
-    });
-  }
-  return parts;
-}
-
-function updateCalculationResult() {
-  const parts = collectParts();
-  const totalInvestment = calculatePartsTotal(parts);
-  const yearsOfUse = Number(elements.yearsOfUse.value);
-  const monthlyCost = Number.isFinite(yearsOfUse) && yearsOfUse > 0 ? totalInvestment / (yearsOfUse * 12) : 0;
-
-  elements.calculationTotal.textContent = formatCurrency(totalInvestment);
-  elements.calculationMonthlyCost.textContent = formatMonthlyCost(monthlyCost);
-}
-
 function collectPcItem() {
   const existingItem = state.items.find((item) => item.id === state.editingId);
-  const parts = collectParts();
-  return normalizePcItem({
+  return normalizePcPartItem({
     id: elements.id.value || createId(),
-    category: "pc",
-    itemName: elements.itemName.value.trim(),
-    usage: elements.usage.value,
+    partName: elements.partName.value.trim(),
+    modelNumber: elements.modelNumber.value.trim(),
+    pcName: elements.pcName.value,
+    specDetail: elements.specDetail.value.trim(),
     purchaseDate: elements.purchaseDate.value,
+    purchasePrice: parseCurrencyInputValue(elements.purchasePrice.value),
     yearsOfUse: Number(elements.yearsOfUse.value),
+    endOfUseDate: elements.endOfUseDate.value,
     hideFromTimeline: elements.hideFromTimeline.checked,
-    parts,
     createdAt: existingItem?.createdAt ?? Date.now(),
     updatedAt: Date.now(),
   });
 }
 
 function resetForm() {
+  if (!elements.form) return;
   state.editingId = null;
   elements.form.reset();
   elements.id.value = "";
-  elements.usage.value = "work";
+  elements.pcName.value = "main";
   elements.yearsOfUse.value = "5";
   elements.hideFromTimeline.checked = false;
   elements.submitButton.textContent = "登録する";
   elements.cancelButton.hidden = true;
   elements.formError.textContent = "";
-  renderPartRows([]);
   updateCalculationResult();
 }
 
+function updateEndedUseStyle() {
+  if (!elements.formPanel || !elements.endOfUseDate) return;
+  elements.formPanel.classList.toggle("ended-use", Boolean(elements.endOfUseDate.value));
+}
+
 function fillForm(item) {
+  if (!elements.form) return;
   state.editingId = item.id;
   elements.id.value = item.id;
-  elements.itemName.value = item.itemName;
-  elements.usage.value = item.usage;
+  elements.partName.value = item.partName;
+  elements.modelNumber.value = item.modelNumber;
+  elements.pcName.value = item.pcName;
+  elements.specDetail.value = item.specDetail;
   elements.purchaseDate.value = item.purchaseDate;
+  elements.purchasePrice.value = item.purchasePrice;
   elements.yearsOfUse.value = item.yearsOfUse;
+  elements.endOfUseDate.value = item.endOfUseDate;
   elements.hideFromTimeline.checked = Boolean(item.hideFromTimeline);
   elements.submitButton.textContent = "更新する";
   elements.cancelButton.hidden = false;
   elements.formError.textContent = "";
-  renderPartRows(item.parts);
+  updateEndedUseStyle();
   updateCalculationResult();
-  window.scrollTo({ top: 0, behavior: "smooth" });
 }
 
-function renderSummary() {
-  const totalInvestment = state.items.reduce((total, item) => total + calculateTotalInvestment(item), 0);
-  const monthlyCost = state.items.reduce((total, item) => total + calculateMonthlyCost(item), 0);
-  elements.summaryCount.textContent = `${state.items.length}台`;
-  elements.summaryTotal.textContent = formatCurrency(totalInvestment);
-  elements.summaryMonthly.textContent = formatCurrency(monthlyCost);
-}
-
-function renderParts(parts) {
-  const sortedParts = sortParts(parts);
-  if (sortedParts.length === 0) {
-    return '<p class="pc-card-meta">パーツはまだ入力されていません。</p>';
+function updateCalculationResult() {
+  if (!elements.calculationMonthlyCost) return;
+  const purchasePrice = parseCurrencyInputValue(elements.purchasePrice.value);
+  const monthlyCost = calculateMonthlyCost({
+    purchasePrice,
+    yearsOfUse: Number(elements.yearsOfUse.value),
+  });
+  if (elements.calculationTotal) {
+    elements.calculationTotal.textContent = formatCurrency(purchasePrice);
   }
-  return `
-    <div class="history-list">
-      ${sortedParts
-        .map(
-          (part) => `
-            <div class="history-row">
-              <span data-label="購入日">${escapeHtml(part.purchaseDate)}</span>
-              <span data-label="種別">${escapeHtml(partTypeLabels[part.partType] ?? "その他")}</span>
-              <strong data-label="パーツ名">${escapeHtml(part.partName)}</strong>
-              <span data-label="費用">${formatCurrency(part.price)}</span>
-              <span data-label="メモ">${escapeHtml(part.memo)}</span>
-            </div>
-          `
-        )
-        .join("")}
-    </div>
-  `;
-}
-
-function renderSpecGrid(specs) {
-  return currentSpecTypes
-    .map((specType) => {
-      const emptyText = specType === "gpu" ? "未搭載" : "未入力";
-      return `
-        <div>
-          <dt>${escapeHtml(partTypeLabels[specType])}</dt>
-          <dd>${escapeHtml(specs[specType] || emptyText)}</dd>
-        </div>
-      `;
-    })
-    .join("");
-}
-
-function showPartsDialog(item) {
-  elements.partsDialogTitle.textContent = `${item.itemName}のパーツ一覧`;
-  elements.partsDialogBody.innerHTML = renderParts(item.parts);
-
-  if (typeof elements.partsDialog.showModal === "function") {
-    elements.partsDialog.showModal();
-    return;
-  }
-
-  elements.partsDialog.setAttribute("open", "");
-}
-
-function renderList() {
-  elements.pcList.innerHTML = "";
-  if (state.items.length === 0) {
-    elements.pcList.innerHTML = '<div class="empty">PCはまだ登録されていません。</div>';
-    return;
-  }
-
-  for (const item of sortItems(state.items)) {
-    const totalInvestment = calculateTotalInvestment(item);
-    const monthlyCost = calculateMonthlyCost(item);
-
-    const card = document.createElement("article");
-    card.className = "pc-card";
-    card.innerHTML = `
-      <div class="pc-card-header">
-        <div>
-          <h3 class="pc-card-title">${escapeHtml(item.itemName)}</h3>
-          <p class="pc-card-meta">
-            用途: ${escapeHtml(usageLabels[item.usage] ?? "その他")} / 組立日: ${escapeHtml(item.purchaseDate)}
-          </p>
-        </div>
-        <div class="card-actions">
-          <button class="primary-button small-button edit-button" type="button" data-id="${escapeHtml(item.id)}">編集</button>
-          <button class="danger-button small-button delete-button" type="button" data-id="${escapeHtml(item.id)}">削除</button>
-        </div>
-      </div>
-
-      <div class="pc-cost-summary">
-        <div>
-          <span class="cost-label">総投資額</span>
-          <strong>${formatCurrency(totalInvestment)}</strong>
-        </div>
-        <div>
-          <span class="cost-label">月額換算</span>
-          <strong>${formatCurrency(monthlyCost)}</strong>
-        </div>
-      </div>
-
-      <dl class="spec-grid">
-        ${renderSpecGrid(item.specs)}
-      </dl>
-
-      <button
-        class="part-summary-card parts-dialog-button"
-        type="button"
-        data-id="${escapeHtml(item.id)}"
-        aria-label="${escapeHtml(item.itemName)}のパーツ一覧を表示"
-      >
-        <span>パーツ一覧</span>
-        <strong>${item.parts.length}件</strong>
-      </button>
-    `;
-    elements.pcList.appendChild(card);
-  }
-}
-
-function render() {
-  renderSummary();
-  renderList();
+  elements.calculationMonthlyCost.textContent = formatMonthlyCost(monthlyCost);
 }
 
 async function refreshItems() {
   if (!state.uid) return;
   state.items = await loadFirestoreItems(state.uid);
+  if (!state.items.some((item) => item.id === state.selectedItemId)) {
+    state.selectedItemId = visibleItems()[0]?.id ?? null;
+  }
   render();
-  if (state.editingId) {
+  if (state.editingId && elements.form) {
     const item = state.items.find((currentItem) => currentItem.id === state.editingId);
     if (item) fillForm(item);
   }
 }
 
-function showError(error, fallback) {
-  elements.authError.textContent = firebaseErrorMessage(error, fallback);
+function selectedItem() {
+  return state.items.find((item) => item.id === state.selectedItemId) ?? null;
 }
 
-elements.addPartButton.addEventListener("click", () => {
-  const row = createPartRow({ createdAt: Date.now() });
-  elements.partList.prepend(row);
-  row.querySelector(".part-purchase-date").focus();
-  updateCalculationResult();
-});
+function openItemDialog(item) {
+  if (!item || !elements.itemDialog) return;
+  elements.dialogItemName.textContent = item.partName || "商品名未入力";
+  elements.dialogItemMeta.textContent =
+    `${pcNameLabels[item.pcName] || "メインPC"} / 型番: ${item.modelNumber || "未入力"} / ${formatMonthlyCost(calculateMonthlyCost(item))}`;
+  elements.itemDialog.showModal();
+}
 
-elements.partList.addEventListener("click", (event) => {
-  const target = event.target;
-  if (!(target instanceof HTMLElement)) return;
-  if (!target.classList.contains("part-delete")) return;
-  target.closest(".part-row")?.remove();
-  if (elements.partList.children.length === 0) {
-    elements.partList.appendChild(createPartRow({ createdAt: Date.now() }));
+function selectItem(itemId) {
+  state.selectedItemId = itemId;
+  renderTimeline();
+  openItemDialog(selectedItem());
+}
+
+function showError(error, fallback) {
+  if (elements.authError) {
+    elements.authError.textContent = firebaseErrorMessage(error, fallback);
   }
-  updateCalculationResult();
-});
+}
 
-elements.form.addEventListener("input", updateCalculationResult);
-elements.form.addEventListener("change", updateCalculationResult);
-elements.yearsOfUse.addEventListener("input", updateCalculationResult);
-elements.partList.addEventListener("input", updateCalculationResult);
-elements.partList.addEventListener("change", updateCalculationResult);
+if (elements.form) {
+  elements.form.addEventListener("input", updateCalculationResult);
+  elements.form.addEventListener("change", updateCalculationResult);
+  elements.endOfUseDate.addEventListener("input", updateEndedUseStyle);
 
-elements.partsDialogClose.addEventListener("click", () => {
-  elements.partsDialog.close();
-});
+  elements.form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    elements.formError.textContent = "";
+    elements.authError.textContent = "";
 
-elements.partsDialog.addEventListener("click", (event) => {
-  if (event.target === elements.partsDialog) {
-    elements.partsDialog.close();
-  }
-});
-
-elements.form.addEventListener("submit", async (event) => {
-  event.preventDefault();
-  elements.formError.textContent = "";
-  elements.authError.textContent = "";
-
-  if (!state.uid) {
-    elements.formError.textContent = "ログイン状態を確認できません。もう一度ログインしてください。";
-    return;
-  }
-
-  const item = collectPcItem();
-  const validation = validatePcItem(item);
-  if (validation) {
-    elements.formError.textContent = validation;
-    return;
-  }
-
-  try {
-    elements.submitButton.disabled = true;
-    await saveFirestoreItem(state.uid, item);
-    await refreshItems();
-    resetForm();
-  } catch (error) {
-    elements.formError.textContent = firebaseErrorMessage(error, "PC情報の保存に失敗しました。");
-  } finally {
-    elements.submitButton.disabled = false;
-  }
-});
-
-elements.cancelButton.addEventListener("click", () => {
-  resetForm();
-});
-
-elements.resetButton.addEventListener("click", () => {
-  resetForm();
-});
-
-elements.pcList.addEventListener("click", async (event) => {
-  const target = event.target;
-  if (!(target instanceof HTMLElement)) return;
-
-  const editButton = target.closest(".edit-button");
-  if (editButton instanceof HTMLButtonElement) {
-    const item = state.items.find((currentItem) => currentItem.id === editButton.dataset.id);
-    if (item) fillForm(item);
-    return;
-  }
-
-  const partsDialogButton = target.closest(".parts-dialog-button");
-  if (partsDialogButton instanceof HTMLButtonElement) {
-    const item = state.items.find((currentItem) => currentItem.id === partsDialogButton.dataset.id);
-    if (item) showPartsDialog(item);
-    return;
-  }
-
-  const deleteButton = target.closest(".delete-button");
-  if (!(deleteButton instanceof HTMLButtonElement)) return;
-  if (!state.uid) return;
-
-  const item = state.items.find((currentItem) => currentItem.id === deleteButton.dataset.id);
-  if (!item) return;
-
-  const shouldDelete = confirm(`「${item.itemName}」を削除しますか？`);
-  if (!shouldDelete) return;
-
-  try {
-    deleteButton.disabled = true;
-    await removeFirestoreItem(state.uid, item.id);
-    await refreshItems();
-    if (state.editingId === item.id) resetForm();
-  } catch (error) {
-    showError(error, "PC情報の削除に失敗しました。");
-  } finally {
-    deleteButton.disabled = false;
-  }
-});
-
-elements.exportButton.addEventListener("click", () => {
-  const payload = {
-    dataVersion: DATA_VERSION,
-    exportedAt: new Date().toISOString(),
-    pcItems: sortItems(state.items).map(normalizePcItem),
-  };
-  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = "pc-management-data.json";
-  link.click();
-  URL.revokeObjectURL(url);
-});
-
-elements.importFile.addEventListener("change", async () => {
-  const file = elements.importFile.files?.[0];
-  if (!file || !state.uid) return;
-  elements.formError.textContent = "";
-  elements.authError.textContent = "";
-
-  try {
-    const text = await file.text();
-    const parsed = JSON.parse(text);
-    const items = Array.isArray(parsed) ? parsed : parsed.pcItems;
-    if (!Array.isArray(items)) {
-      throw new Error("PC一覧データが見つかりません。");
-    }
-    const shouldReplace = confirm("読み込んだJSONでFirestore上のPC一覧を置き換えますか？");
-    if (!shouldReplace) return;
-    const importedItems = items.map(normalizePcItem);
-    state.items = sortItems(importedItems);
-    saveLocalBackupItems(state.items);
-    render();
-    resetForm();
-    try {
-      await replaceFirestoreItems(state.uid, state.items);
-      await refreshItems();
-      localStorage.removeItem(LOCAL_STORAGE_KEY);
-    } catch (error) {
-      elements.formError.textContent = firebaseErrorMessage(
-        error,
-        "JSONは画面に反映しましたが、Firestoreへの保存に失敗しました。"
-      );
+    if (!state.uid) {
+      elements.formError.textContent = "ログイン状態を確認できません。もう一度ログインしてください。";
       return;
     }
-    resetForm();
-  } catch (error) {
-    elements.formError.textContent = firebaseErrorMessage(error, "JSONの読み込みに失敗しました。");
-  } finally {
-    elements.importFile.value = "";
-  }
+
+    const item = collectPcItem();
+    const validation = validatePcItem(item);
+    if (validation) {
+      elements.formError.textContent = validation;
+      return;
+    }
+
+    try {
+      elements.submitButton.disabled = true;
+      await saveFirestoreItem(state.uid, item);
+      window.location.href = "index.html";
+    } catch (error) {
+      elements.formError.textContent = firebaseErrorMessage(error, "パーツ情報の保存に失敗しました。");
+    } finally {
+      elements.submitButton.disabled = false;
+    }
+  });
+
+  elements.cancelButton.addEventListener("click", () => {
+    window.location.href = "index.html";
+  });
+  elements.toListButton.addEventListener("click", () => {
+    window.location.href = "index.html";
+  });
+}
+
+if (elements.createButton) {
+  elements.createButton.addEventListener("click", () => {
+    window.location.href = "form.html";
+  });
+}
+
+if (elements.hiddenButton) {
+  elements.hiddenButton.addEventListener("click", () => {
+    window.location.href = "hidden.html";
+  });
+}
+
+if (elements.backButton) {
+  elements.backButton.addEventListener("click", () => {
+    window.location.href = TIMELINE_MODE === "hidden" ? "index.html" : "../list.html";
+  });
+}
+
+if (elements.helpButton && elements.helpDialog && elements.helpCloseButton) {
+  elements.helpButton.addEventListener("click", () => {
+    elements.helpDialog.showModal();
+  });
+
+  elements.helpCloseButton.addEventListener("click", () => {
+    elements.helpDialog.close();
+  });
+
+  elements.helpDialog.addEventListener("click", (event) => {
+    if (event.target === elements.helpDialog) elements.helpDialog.close();
+  });
+}
+
+if (elements.itemList) {
+  elements.itemList.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const band = target.closest(".lifecycle-band, .post-end-band");
+    if (!(band instanceof HTMLButtonElement)) return;
+    selectItem(band.dataset.id ?? "");
+  });
+}
+
+if (elements.dialogEditButton) {
+  elements.dialogEditButton.addEventListener("click", () => {
+    const item = selectedItem();
+    if (!item) return;
+    window.location.href = `form.html?id=${encodeURIComponent(item.id)}`;
+  });
+}
+
+if (elements.dialogDeleteButton) {
+  elements.dialogDeleteButton.addEventListener("click", async () => {
+    const item = selectedItem();
+    if (!item || !state.uid) return;
+    const shouldDelete = confirm(`「${item.partName}」を削除しますか？`);
+    if (!shouldDelete) return;
+
+    try {
+      elements.dialogDeleteButton.disabled = true;
+      await removeFirestoreItem(state.uid, item.id);
+      elements.itemDialog.close();
+      state.selectedItemId = null;
+      await refreshItems();
+      if (state.editingId === item.id) resetForm();
+    } catch (error) {
+      showError(error, "パーツ情報の削除に失敗しました。");
+    } finally {
+      elements.dialogDeleteButton.disabled = false;
+    }
+  });
+}
+
+if (elements.dialogCloseButton) {
+  elements.dialogCloseButton.addEventListener("click", () => {
+    elements.itemDialog.close();
+  });
+}
+
+if (elements.itemDialog) {
+  elements.itemDialog.addEventListener("click", (event) => {
+    if (event.target === elements.itemDialog) elements.itemDialog.close();
+  });
+}
+
+window.addEventListener("resize", () => {
+  window.clearTimeout(state.resizeTimer);
+  state.resizeTimer = window.setTimeout(renderTimeline, 120);
 });
 
-renderPartRows([]);
 updateCalculationResult();
+updateEndedUseStyle();
 render();
 
 onAuthChanged(async (user) => {
@@ -827,13 +775,33 @@ onAuthChanged(async (user) => {
   }
 
   state.uid = user.uid;
-  elements.authError.textContent = "";
+  if (elements.authError) elements.authError.textContent = "";
 
   try {
-    await refreshItems();
-    await migrateLocalItemsIfNeeded(user.uid);
+    if (!elements.form) {
+      await refreshItems();
+      return;
+    }
+
+    if (!state.editingId) {
+      elements.submitButton.textContent = "登録する";
+      elements.cancelButton.hidden = true;
+      elements.pcName.value = "main";
+      elements.yearsOfUse.value = elements.yearsOfUse.value || "5";
+      updateEndedUseStyle();
+      updateCalculationResult();
+      return;
+    }
+
+    state.items = await loadFirestoreItems(state.uid);
+    const item = state.items.find((currentItem) => currentItem.id === state.editingId);
+    if (!item) {
+      elements.authError.textContent = "編集対象が見つかりません。";
+      return;
+    }
+    fillForm(item);
   } catch (error) {
-    showError(error, "PC情報の取得に失敗しました。");
+    showError(error, "パーツ情報の取得に失敗しました。");
   }
 });
 

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -81,12 +81,13 @@ const elements = {
   usage: document.getElementById("usage"),
   purchaseDate: document.getElementById("purchase-date"),
   yearsOfUse: document.getElementById("years-of-use"),
+  hideFromTimeline: document.getElementById("hide-from-timeline"),
 };
 
 const state = {
   uid: null,
   items: [],
-  editingId: null,
+  editingId: new URLSearchParams(window.location.search).get("id"),
 };
 
 function createId() {
@@ -269,6 +270,7 @@ function normalizePcItem(value) {
     purchaseDate: String(item.purchaseDate ?? ""),
     price: parts.length > 0 ? calculatePartsTotal(parts) : fallbackPrice,
     yearsOfUse: Number(item.yearsOfUse ?? 5),
+    hideFromTimeline: Boolean(item.hideFromTimeline),
     specs: deriveCurrentSpecs(parts, legacySpecs),
     parts,
     createdAt: toMillis(item.createdAt),
@@ -302,6 +304,7 @@ function toFirestorePayload(item) {
     price: totalInvestment,
     purchasePrice: totalInvestment,
     yearsOfUse: normalized.yearsOfUse,
+    hideFromTimeline: Boolean(normalized.hideFromTimeline),
     monthlyCost: calculateMonthlyCost(normalized),
     specs: normalized.specs,
     parts: normalized.parts,
@@ -478,6 +481,7 @@ function collectPcItem() {
     usage: elements.usage.value,
     purchaseDate: elements.purchaseDate.value,
     yearsOfUse: Number(elements.yearsOfUse.value),
+    hideFromTimeline: elements.hideFromTimeline.checked,
     parts,
     createdAt: existingItem?.createdAt ?? Date.now(),
     updatedAt: Date.now(),
@@ -490,6 +494,7 @@ function resetForm() {
   elements.id.value = "";
   elements.usage.value = "work";
   elements.yearsOfUse.value = "5";
+  elements.hideFromTimeline.checked = false;
   elements.submitButton.textContent = "登録する";
   elements.cancelButton.hidden = true;
   elements.formError.textContent = "";
@@ -504,6 +509,7 @@ function fillForm(item) {
   elements.usage.value = item.usage;
   elements.purchaseDate.value = item.purchaseDate;
   elements.yearsOfUse.value = item.yearsOfUse;
+  elements.hideFromTimeline.checked = Boolean(item.hideFromTimeline);
   elements.submitButton.textContent = "更新する";
   elements.cancelButton.hidden = false;
   elements.formError.textContent = "";
@@ -635,6 +641,10 @@ async function refreshItems() {
   if (!state.uid) return;
   state.items = await loadFirestoreItems(state.uid);
   render();
+  if (state.editingId) {
+    const item = state.items.find((currentItem) => currentItem.id === state.editingId);
+    if (item) fillForm(item);
+  }
 }
 
 function showError(error, fallback) {

--- a/pc-management/form.html
+++ b/pc-management/form.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>登録・編集 | パソコン管理</title>
+    <meta name="theme-color" content="#2563eb" />
+    <link rel="manifest" href="../manifest.webmanifest" />
+    <link rel="icon" href="../icons/icon-192.png" type="image/png" />
+    <link rel="apple-touch-icon" href="../icons/icon-192.png" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app-header">
+        <h1>パソコン管理</h1>
+        <p class="subtitle">登録・編集</p>
+      </header>
+
+      <section id="form-panel" class="panel" aria-labelledby="form-title">
+        <h2 id="form-title">入力フォーム</h2>
+        <p id="auth-error" class="form-error"></p>
+        <form id="pc-form" novalidate>
+          <input id="pc-id" type="hidden" />
+
+          <label for="part-name">商品名（パーツ）</label>
+          <input id="part-name" type="text" autocomplete="off" required />
+          <label for="model-number">型番</label>
+          <input id="model-number" type="text" autocomplete="off" required />
+          <label for="pc-name">分類（パソコン名）</label>
+          <select id="pc-name" required>
+            <option value="main">メインPC</option>
+            <option value="sub">サブPC</option>
+          </select>
+          <label for="spec-detail">スペック（詳細入力欄）</label>
+          <textarea id="spec-detail" rows="4"></textarea>
+          <label for="purchase-date">購入日</label>
+          <input id="purchase-date" type="date" required />
+          <label for="purchase-price">購入価格（円）</label>
+          <input id="purchase-price" type="number" inputmode="numeric" min="0" step="1" required />
+          <label for="years-of-use">使用年数（年）</label>
+          <input id="years-of-use" type="number" inputmode="numeric" min="1" step="1" value="5" required />
+          <label for="end-of-use-date">使用終了日</label>
+          <input id="end-of-use-date" type="date" />
+
+          <section class="calculation-result" aria-label="計算結果">
+            <div>
+              <span>合計</span>
+              <strong id="calculation-total">¥0</strong>
+            </div>
+            <div>
+              <span>月額コスト</span>
+              <strong id="calculation-monthly-cost">¥0 /月</strong>
+            </div>
+          </section>
+
+          <p id="form-error" class="form-error"></p>
+          <label class="checkbox-field" for="hide-from-timeline">
+            <input id="hide-from-timeline" type="checkbox" />
+            <span>帯を表示しない</span>
+          </label>
+          <div class="form-actions">
+            <button id="submit-button" class="primary-button" type="submit">登録する</button>
+            <button id="cancel-button" class="ghost-button" type="button" hidden>編集をキャンセル</button>
+          </div>
+          <button id="to-list-button" class="ghost-button" type="button">一覧に戻る</button>
+        </form>
+      </section>
+    </main>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/pc-management/hidden.html
+++ b/pc-management/hidden.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>非表示パーツ | パソコン管理</title>
+    <meta name="theme-color" content="#1f2933" />
+    <link rel="manifest" href="../manifest.webmanifest" />
+    <link rel="icon" href="../icons/icon-192.png" type="image/png" />
+    <link rel="apple-touch-icon" href="../icons/icon-192.png" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body class="dashboard-body" data-timeline-mode="hidden">
+    <main class="app dashboard-app">
+      <header class="app-header dashboard-header">
+        <div class="dashboard-title">
+          <h1>非表示パーツ</h1>
+        </div>
+        <div class="dashboard-actions">
+          <button id="back-button" type="button" class="ghost-button">戻る</button>
+        </div>
+      </header>
+
+      <section class="panel timeline-panel" aria-labelledby="list-title">
+        <h2 id="list-title">ライフサイクル年表</h2>
+        <p id="auth-error" class="form-error"></p>
+        <div id="item-list" class="timeline-shell"></div>
+      </section>
+    </main>
+
+    <dialog id="item-dialog" class="item-name-dialog">
+      <article class="item-name-dialog-card">
+        <h2 id="dialog-item-name"></h2>
+        <p id="dialog-item-meta" class="dialog-item-meta"></p>
+        <div class="dialog-actions">
+          <button id="dialog-edit-button" type="button" class="primary-button">編集</button>
+          <button id="dialog-delete-button" type="button" class="danger-button">削除</button>
+          <button id="dialog-close-button" type="button" class="ghost-button">閉じる</button>
+        </div>
+      </article>
+    </dialog>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/pc-management/index.html
+++ b/pc-management/index.html
@@ -83,6 +83,10 @@
           </section>
 
           <p id="form-error" class="form-error" aria-live="polite"></p>
+          <label class="checkbox-field" for="hide-from-timeline">
+            <input id="hide-from-timeline" type="checkbox" />
+            <span>帯を表示しない</span>
+          </label>
           <div class="form-actions">
             <button id="submit-button" class="primary-button" type="submit">登録する</button>
             <button id="cancel-button" class="ghost-button" type="button" hidden>編集をキャンセル</button>

--- a/pc-management/index.html
+++ b/pc-management/index.html
@@ -34,7 +34,6 @@
         <div class="dashboard-actions">
           <button id="create-button" type="button" class="primary-button">新規登録</button>
           <button id="back-button" type="button" class="ghost-button">一覧に戻る</button>
-          <button id="help-button" type="button" class="ghost-button help-button">ヘルプ</button>
         </div>
       </header>
 
@@ -46,6 +45,7 @@
 
       <section class="pc-management-launch" aria-label="非表示パーツ">
         <a class="pc-management-button" href="hidden.html">非表示パーツ</a>
+        <button id="help-button" type="button" class="pc-management-button help-button">ヘルプ</button>
       </section>
     </main>
 

--- a/pc-management/index.html
+++ b/pc-management/index.html
@@ -36,9 +36,7 @@
           <h2 id="form-title">PC情報</h2>
           <button id="reset-button" class="ghost-button small-button" type="button">新規入力</button>
         </div>
-        <p id="auth-status" class="form-mode">状態: 確認中</p>
         <p id="auth-error" class="form-error" aria-live="polite"></p>
-        <p id="form-mode" class="form-mode">現在: 新規登録</p>
 
         <form id="pc-form" novalidate>
           <input id="pc-id" type="hidden" />
@@ -71,6 +69,17 @@
               <button id="add-part-button" class="primary-button small-button" type="button">パーツ追加</button>
             </div>
             <div id="part-list" class="part-list"></div>
+          </section>
+
+          <section class="calculation-result" aria-label="計算結果">
+            <div>
+              <span>合計</span>
+              <strong id="calculation-total">¥0</strong>
+            </div>
+            <div>
+              <span>月額コスト</span>
+              <strong id="calculation-monthly-cost">¥0 /月</strong>
+            </div>
           </section>
 
           <p id="form-error" class="form-error" aria-live="polite"></p>

--- a/pc-management/index.html
+++ b/pc-management/index.html
@@ -3,142 +3,90 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>自作PC管理</title>
-    <link rel="stylesheet" href="styles.css" />
+    <title>パソコン管理</title>
+    <meta name="theme-color" content="#1f2933" />
+    <link rel="manifest" href="../manifest.webmanifest" />
+    <link rel="icon" href="../icons/icon-192.png" type="image/png" />
+    <link rel="apple-touch-icon" href="../icons/icon-192.png" />
+    <link rel="stylesheet" href="../style.css" />
   </head>
-  <body>
-    <main class="app">
-      <header class="app-header">
-        <div>
-          <h1>自作PC管理</h1>
-          <p>部品ごとの購入費と現在スペックを管理します。</p>
+  <body class="dashboard-body" data-timeline-mode="visible">
+    <main class="app dashboard-app">
+      <header class="app-header dashboard-header">
+        <div class="dashboard-title">
+          <h1>パソコン管理</h1>
+          <p class="subtitle">パーツの月割りコスト管理</p>
         </div>
-        <a class="back-link" href="../list.html">一覧に戻る</a>
+        <section class="summary-panel" aria-label="集計">
+          <div class="summary-item summary-item-primary">
+            <span class="summary-label">現在の月額合計</span>
+            <strong id="summary-monthly">¥0 /月</strong>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">総購入額(現在使用中)</span>
+            <strong id="summary-total">¥0</strong>
+          </div>
+          <div class="summary-item">
+            <span class="summary-label">登録数</span>
+            <strong id="summary-count">0 件</strong>
+          </div>
+        </section>
+        <div class="dashboard-actions">
+          <button id="create-button" type="button" class="primary-button">新規登録</button>
+          <button id="back-button" type="button" class="ghost-button">一覧に戻る</button>
+          <button id="help-button" type="button" class="ghost-button help-button">ヘルプ</button>
+        </div>
       </header>
 
-      <section class="summary-grid" aria-label="全体サマリー">
-        <article class="summary-card">
-          <span>登録PC</span>
-          <strong id="summary-count">0台</strong>
-        </article>
-        <article class="summary-card">
-          <span>総投資額</span>
-          <strong id="summary-total">¥0</strong>
-        </article>
-        <article class="summary-card">
-          <span>月額換算</span>
-          <strong id="summary-monthly">¥0</strong>
-        </article>
+      <section class="panel timeline-panel" aria-labelledby="list-title">
+        <h2 id="list-title">ライフサイクル年表</h2>
+        <p id="auth-error" class="form-error"></p>
+        <div id="item-list" class="timeline-shell"></div>
       </section>
 
-      <section class="panel" aria-labelledby="form-title">
-        <div class="section-heading">
-          <h2 id="form-title">PC情報</h2>
-          <button id="reset-button" class="ghost-button small-button" type="button">新規入力</button>
-        </div>
-        <p id="auth-error" class="form-error" aria-live="polite"></p>
-
-        <form id="pc-form" novalidate>
-          <input id="pc-id" type="hidden" />
-
-          <label for="item-name">PC名</label>
-          <input id="item-name" type="text" autocomplete="off" placeholder="メインPC" required />
-
-          <label for="usage">用途</label>
-          <select id="usage" required>
-            <option value="work">仕事</option>
-            <option value="game">ゲーム</option>
-            <option value="development">開発</option>
-            <option value="other">その他</option>
-          </select>
-
-          <div class="form-grid">
-            <div>
-              <label for="purchase-date">組立日</label>
-              <input id="purchase-date" type="date" required />
-            </div>
-            <div>
-              <label for="years-of-use">想定使用年数（年）</label>
-              <input id="years-of-use" type="number" inputmode="numeric" min="1" step="1" value="5" required />
-            </div>
-          </div>
-
-          <section class="subsection" aria-labelledby="parts-title">
-            <div class="section-heading">
-              <h3 id="parts-title">パーツ入力</h3>
-              <button id="add-part-button" class="primary-button small-button" type="button">パーツ追加</button>
-            </div>
-            <div id="part-list" class="part-list"></div>
-          </section>
-
-          <section class="calculation-result" aria-label="計算結果">
-            <div>
-              <span>合計</span>
-              <strong id="calculation-total">¥0</strong>
-            </div>
-            <div>
-              <span>月額コスト</span>
-              <strong id="calculation-monthly-cost">¥0 /月</strong>
-            </div>
-          </section>
-
-          <p id="form-error" class="form-error" aria-live="polite"></p>
-          <label class="checkbox-field" for="hide-from-timeline">
-            <input id="hide-from-timeline" type="checkbox" />
-            <span>帯を表示しない</span>
-          </label>
-          <div class="form-actions">
-            <button id="submit-button" class="primary-button" type="submit">登録する</button>
-            <button id="cancel-button" class="ghost-button" type="button" hidden>編集をキャンセル</button>
-          </div>
-        </form>
-      </section>
-
-      <section class="panel" aria-labelledby="list-title">
-        <div class="section-heading">
-          <h2 id="list-title">登録済みPC</h2>
-          <div class="toolbar">
-            <button id="export-button" class="ghost-button small-button" type="button">JSON出力</button>
-            <label class="ghost-button small-button file-button" for="import-file">JSON読込</label>
-            <input id="import-file" type="file" accept="application/json" />
-          </div>
-        </div>
-        <div id="pc-list" class="pc-list"></div>
+      <section class="pc-management-launch" aria-label="非表示パーツ">
+        <a class="pc-management-button" href="hidden.html">非表示パーツ</a>
       </section>
     </main>
 
-    <dialog id="parts-dialog" class="parts-dialog" aria-labelledby="parts-dialog-title">
-      <div class="dialog-header">
-        <div>
-          <p class="dialog-subtitle">パーツ一覧</p>
-          <h2 id="parts-dialog-title">パーツ一覧</h2>
+    <dialog id="help-dialog" class="help-dialog">
+      <article class="help-dialog-card">
+        <div class="help-dialog-header">
+          <h2>ヘルプ</h2>
+          <button id="help-close-button" type="button" class="ghost-button">閉じる</button>
         </div>
-        <button id="parts-dialog-close" class="ghost-button small-button" type="button">閉じる</button>
-      </div>
-      <div id="parts-dialog-body" class="dialog-body"></div>
+
+        <section class="help-section" aria-labelledby="help-legend-title">
+          <h3 id="help-legend-title">帯の凡例</h3>
+          <div class="timeline-legend help-legend" aria-label="帯の色の凡例">
+            <span class="legend-item"><span class="legend-band category-pc-main"></span>メインPC</span>
+            <span class="legend-item"><span class="legend-band category-pc-sub"></span>サブPC</span>
+            <span class="legend-item"><span class="legend-band legend-overused"></span>濃い部分は使用年数超過</span>
+            <span class="legend-item"><span class="legend-band legend-unused"></span>無色部分は使用年数に達しなかった期間</span>
+          </div>
+        </section>
+
+        <section class="help-section" aria-labelledby="help-concept-title">
+          <h3 id="help-concept-title">このアプリのコンセプト</h3>
+          <p>このアプリは、パソコンを本体単位ではなく、CPU、GPU、メモリ、ストレージ、電源、モニターなどのパーツ単位で管理するためのツールです。</p>
+          <p>パーツごとに購入日、購入価格、使用年数、使用終了日を記録し、それぞれをライフサイクル年表の帯として表示します。これにより、どのパーツをいつ購入し、いつ頃まで使う予定なのかをひと目で確認できます。</p>
+          <p>パソコンは一度に丸ごと買い替えるだけでなく、パーツ単位で交換・増設することが多いため、パーツごとの月額コストや使用期間を分けて見ることで、次に交換すべき部品や、長く使えている部品を判断しやすくします。</p>
+          <p>メインPCとサブPCで帯の色を分けることで、複数のパソコンに使っているパーツを混同せずに管理できます。</p>
+        </section>
+      </article>
     </dialog>
 
-    <template id="part-row-template">
-      <div class="part-row">
-        <select class="part-type" aria-label="パーツ種別">
-          <option value="cpu">CPU</option>
-          <option value="gpu">GPU</option>
-          <option value="motherboard">マザーボード</option>
-          <option value="memory">メモリ</option>
-          <option value="storage">ストレージ</option>
-          <option value="power_supply">電源</option>
-          <option value="monitor">モニター</option>
-          <option value="os">OS</option>
-          <option value="other">その他</option>
-        </select>
-        <input class="part-purchase-date" type="date" aria-label="購入日" />
-        <input class="part-name" type="text" autocomplete="off" placeholder="パーツ名" aria-label="パーツ名" />
-        <input class="part-price" type="number" inputmode="numeric" min="0" step="1" placeholder="費用" aria-label="費用" />
-        <input class="part-memo" type="text" autocomplete="off" placeholder="メモ" aria-label="メモ" />
-        <button class="danger-button small-button part-delete" type="button">削除</button>
-      </div>
-    </template>
-
+    <dialog id="item-dialog" class="item-name-dialog">
+      <article class="item-name-dialog-card">
+        <h2 id="dialog-item-name"></h2>
+        <p id="dialog-item-meta" class="dialog-item-meta"></p>
+        <div class="dialog-actions">
+          <button id="dialog-edit-button" type="button" class="primary-button">編集</button>
+          <button id="dialog-delete-button" type="button" class="danger-button">削除</button>
+          <button id="dialog-close-button" type="button" class="ghost-button">閉じる</button>
+        </div>
+      </article>
+    </dialog>
     <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/pc-management/styles.css
+++ b/pc-management/styles.css
@@ -205,6 +205,32 @@ select:focus {
   margin-top: 4px;
 }
 
+.calculation-result {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: #f3f8f6;
+}
+
+.calculation-result div {
+  display: grid;
+  gap: 4px;
+}
+
+.calculation-result span {
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.calculation-result strong {
+  color: var(--primary-strong);
+  font-size: 1.2rem;
+}
+
 button,
 .file-button {
   min-height: 44px;
@@ -454,6 +480,7 @@ button {
   .summary-grid,
   .form-grid,
   .pc-cost-summary,
+  .calculation-result,
   .spec-grid {
     grid-template-columns: 1fr;
   }

--- a/pc-management/styles.css
+++ b/pc-management/styles.css
@@ -469,6 +469,26 @@ button {
     grid-template-columns: 1fr;
   }
 
+  .history-row {
+    gap: 6px;
+  }
+
+  .history-row span,
+  .history-row strong {
+    display: grid;
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 8px;
+    align-items: baseline;
+  }
+
+  .history-row span::before,
+  .history-row strong::before {
+    content: attr(data-label);
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+
   .part-summary-card {
     grid-template-columns: 1fr;
   }

--- a/pc-management/styles.css
+++ b/pc-management/styles.css
@@ -170,6 +170,20 @@ select {
   font-size: 1rem;
 }
 
+.checkbox-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  font-weight: 700;
+}
+
+.checkbox-field input {
+  width: 18px;
+  height: 18px;
+  padding: 0;
+}
+
 input:focus,
 select:focus {
   border-color: var(--primary);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v29";
+const CACHE_NAME = "durable-goods-pwa-v30";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v34";
+const CACHE_NAME = "durable-goods-pwa-v36";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v36";
+const CACHE_NAME = "durable-goods-pwa-v37";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v31";
+const CACHE_NAME = "durable-goods-pwa-v34";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",
@@ -17,7 +17,7 @@ const APP_SHELL = [
   "manifest.webmanifest",
   "icons/icon-192.png",
   "icons/icon-512.png",
-].map((path) => new URL(path, BASE_URL).toString());
+].map((path) => new Request(new URL(path, BASE_URL).toString(), { cache: "reload" }));
 const FALLBACK_URL = new URL("login.html", BASE_URL).toString();
 
 function isSameOriginRequest(request) {
@@ -61,7 +61,7 @@ self.addEventListener("fetch", (event) => {
   }
 
   event.respondWith(
-    fetch(event.request)
+    fetch(event.request, { cache: "no-store" })
       .then((networkResponse) => {
         if (!networkResponse || networkResponse.status !== 200) {
           return networkResponse;

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v38";
+const CACHE_NAME = "durable-goods-pwa-v41";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",
@@ -13,6 +13,8 @@ const APP_SHELL = [
   "js/list.js",
   "js/form.js",
   "pc-management/index.html",
+  "pc-management/form.html",
+  "pc-management/hidden.html",
   "pc-management/styles.css",
   "pc-management/app.js",
   "manifest.webmanifest",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,10 +1,11 @@
-const CACHE_NAME = "durable-goods-pwa-v37";
+const CACHE_NAME = "durable-goods-pwa-v38";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",
   "index.html",
   "login.html",
   "list.html",
+  "hidden.html",
   "form.html",
   "style.css",
   "js/common.js",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v30";
+const CACHE_NAME = "durable-goods-pwa-v31";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",

--- a/style.css
+++ b/style.css
@@ -366,3 +366,623 @@ button {
     grid-template-columns: 1fr;
   }
 }
+
+.dashboard-body {
+  color-scheme: dark;
+  min-height: 100vh;
+  background:
+    linear-gradient(135deg, rgba(77, 94, 107, 0.24), rgba(16, 23, 31, 0.92)),
+    #1b242d;
+  color: #edf2f7;
+}
+
+.dashboard-app {
+  width: min(1560px, 100%);
+  padding: 18px 16px 28px;
+}
+
+.dashboard-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: minmax(230px, 1fr) minmax(420px, 760px) auto;
+  gap: 18px;
+  align-items: center;
+  padding: 0 0 16px;
+  background: linear-gradient(180deg, rgba(27, 36, 45, 0.98), rgba(27, 36, 45, 0.9));
+  border-bottom: 1px solid rgba(203, 213, 225, 0.16);
+  backdrop-filter: blur(14px);
+}
+
+.dashboard-title h1 {
+  margin: 0;
+  font-size: clamp(1.55rem, 2.4vw, 2rem);
+  letter-spacing: 0;
+}
+
+.dashboard-body .subtitle {
+  margin-top: 12px;
+  color: #c9d4df;
+  font-size: 1rem;
+}
+
+.summary-panel {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 0.75fr;
+  min-height: 112px;
+  border: 1px solid rgba(203, 213, 225, 0.12);
+  border-radius: 6px;
+  background: rgba(60, 73, 85, 0.58);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.summary-item {
+  display: grid;
+  align-content: center;
+  gap: 10px;
+  padding: 18px 28px;
+  border-left: 1px solid rgba(203, 213, 225, 0.24);
+}
+
+.summary-item:first-child {
+  border-left: none;
+}
+
+.summary-label {
+  color: #e5edf5;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.summary-item strong {
+  color: #f8fafc;
+  font-size: clamp(1.55rem, 3vw, 2.4rem);
+  line-height: 1;
+  letter-spacing: 0;
+  text-shadow: 0 0 18px rgba(255, 255, 255, 0.12);
+}
+
+.summary-item:not(.summary-item-primary) strong {
+  font-size: clamp(1.28rem, 2.1vw, 1.75rem);
+}
+
+.dashboard-actions {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) 54px;
+  gap: 10px;
+}
+
+.dashboard-actions button {
+  min-height: 58px;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+
+.dashboard-actions .primary-button {
+  border: 1px solid rgba(226, 232, 240, 0.36);
+  background: rgba(44, 55, 66, 0.65);
+}
+
+.dashboard-actions .primary-button:hover {
+  background: rgba(67, 84, 100, 0.78);
+}
+
+.dashboard-actions .ghost-button {
+  overflow: hidden;
+  color: transparent;
+  border: 1px solid rgba(226, 232, 240, 0.28);
+  background: rgba(36, 46, 57, 0.58);
+  position: relative;
+}
+
+.dashboard-actions .ghost-button::before {
+  content: "⇄";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #e5edf5;
+  font-size: 1.45rem;
+}
+
+.dashboard-body .panel {
+  margin-top: 14px;
+  border: 1px solid rgba(203, 213, 225, 0.12);
+  border-radius: 6px;
+  background: rgba(40, 52, 63, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.dashboard-body h2 {
+  color: #f8fafc;
+}
+
+.dashboard-body .form-mode {
+  color: #9fb2c3;
+}
+
+.dashboard-body .form-error {
+  color: #ff7b7b;
+}
+
+.timeline-panel {
+  padding: 0;
+  overflow: hidden;
+}
+
+.timeline-panel > h2,
+.timeline-panel > .form-mode,
+.timeline-panel > .form-error {
+  margin-left: 18px;
+  margin-right: 18px;
+}
+
+.timeline-panel > h2 {
+  margin-top: 18px;
+}
+
+.timeline-shell {
+  min-height: 280px;
+}
+
+.timeline-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.timeline-scroll:focus {
+  outline: 2px solid rgba(59, 163, 255, 0.58);
+  outline-offset: -2px;
+}
+
+.timeline-grid {
+  position: relative;
+  min-height: 276px;
+  padding: 54px 0;
+}
+
+.timeline-grid::before {
+  content: "";
+  position: absolute;
+  top: 54px;
+  right: 0;
+  bottom: 54px;
+  left: var(--label-width);
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(
+      to right,
+      rgba(226, 232, 240, 0.12) 0,
+      rgba(226, 232, 240, 0.12) 1px,
+      transparent 1px,
+      transparent 168px
+    ),
+    linear-gradient(90deg, rgba(17, 24, 32, 0.38), rgba(42, 55, 67, 0.26));
+}
+
+.timeline-axis {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 54px;
+  color: #d7e1ea;
+  font-weight: 800;
+}
+
+.timeline-axis-top {
+  top: 0;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.34);
+}
+
+.timeline-axis-bottom {
+  bottom: 0;
+  border-top: 1px solid rgba(226, 232, 240, 0.34);
+}
+
+.timeline-year {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 1.15rem;
+}
+
+.timeline-axis-top .timeline-year {
+  top: 18px;
+}
+
+.timeline-axis-bottom .timeline-year {
+  bottom: 18px;
+}
+
+.timeline-tick {
+  position: absolute;
+  width: 1px;
+  height: 5px;
+  background: rgba(226, 232, 240, 0.5);
+}
+
+.timeline-axis-top .timeline-tick {
+  bottom: 0;
+}
+
+.timeline-axis-bottom .timeline-tick {
+  top: 0;
+}
+
+.timeline-tick.major {
+  height: 12px;
+  background: rgba(226, 232, 240, 0.85);
+}
+
+.timeline-current-line {
+  position: absolute;
+  top: 42px;
+  bottom: 42px;
+  z-index: 8;
+  width: 2px;
+  background: #51b7ff;
+  box-shadow: 0 0 18px rgba(81, 183, 255, 0.95);
+  pointer-events: none;
+}
+
+.timeline-current-line::before,
+.timeline-current-line::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  border-right: 8px solid transparent;
+  border-left: 8px solid transparent;
+}
+
+.timeline-current-line::before {
+  top: 8px;
+  border-bottom: 14px solid #51b7ff;
+}
+
+.timeline-current-line::after {
+  bottom: 8px;
+  border-top: 14px solid #51b7ff;
+}
+
+.timeline-current-line span {
+  position: sticky;
+  top: 74px;
+  display: inline-block;
+  transform: translateX(-50%);
+  margin-top: 26px;
+  color: #51b7ff;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-shadow: 0 0 12px rgba(81, 183, 255, 0.85);
+}
+
+.timeline-row {
+  position: relative;
+  z-index: 1;
+  height: 74px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.78);
+}
+
+.timeline-row:first-child {
+  border-top: 1px solid rgba(15, 23, 42, 0.78);
+}
+
+.timeline-row-label {
+  position: sticky;
+  left: 0;
+  z-index: 7;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: var(--label-width);
+  height: 100%;
+  padding: 0 18px;
+  background: linear-gradient(90deg, rgba(32, 43, 54, 0.98), rgba(32, 43, 54, 0.9));
+  color: #f8fafc;
+  border-right: 1px solid rgba(226, 232, 240, 0.12);
+}
+
+.timeline-row-label strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 1.02rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-swatch {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  box-shadow: 0 0 12px currentColor;
+}
+
+.lifecycle-band {
+  position: absolute;
+  top: 12px;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: 48px;
+  min-height: 48px;
+  padding: 0 16px;
+  overflow: hidden;
+  color: #f8fafc;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  font-size: 0.95rem;
+  font-weight: 800;
+  text-align: left;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.lifecycle-band[aria-pressed="true"] {
+  outline: 2px solid rgba(255, 255, 255, 0.72);
+  outline-offset: 2px;
+}
+
+.lifecycle-band:hover {
+  filter: brightness(1.08);
+}
+
+.band-purchase,
+.band-cost {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.band-cost {
+  flex: 0 1 auto;
+  text-align: right;
+}
+
+.timeline-end-label {
+  position: absolute;
+  top: 27px;
+  z-index: 2;
+  overflow: hidden;
+  max-width: 180px;
+  font-size: 0.94rem;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-normal {
+  color: #61a7ff;
+}
+
+.status-warning {
+  color: #ffd560;
+}
+
+.status-danger {
+  color: #ff7d55;
+}
+
+.status-ended {
+  color: #aeb8c2;
+}
+
+.status-swatch.status-normal {
+  background: #4b84d8;
+}
+
+.status-swatch.status-warning {
+  background: #e2b845;
+}
+
+.status-swatch.status-danger {
+  background: #db6f42;
+}
+
+.status-swatch.status-ended {
+  background: #818b95;
+}
+
+.lifecycle-band.status-normal {
+  color: #f8fafc;
+  background: linear-gradient(90deg, rgba(48, 100, 189, 0.95), rgba(69, 123, 214, 0.88));
+}
+
+.lifecycle-band.status-warning {
+  color: #f8fafc;
+  background: linear-gradient(90deg, rgba(190, 143, 33, 0.95), rgba(224, 185, 71, 0.9));
+}
+
+.lifecycle-band.status-danger {
+  color: #f8fafc;
+  background: linear-gradient(90deg, rgba(190, 91, 47, 0.96), rgba(218, 111, 66, 0.9));
+}
+
+.lifecycle-band.status-ended {
+  color: #f8fafc;
+  background: linear-gradient(90deg, rgba(107, 117, 127, 0.9), rgba(132, 142, 151, 0.82));
+}
+
+.timeline-empty {
+  display: grid;
+  gap: 8px;
+  min-height: 260px;
+  place-content: center;
+  padding: 28px;
+  color: #b9c6d3;
+  text-align: center;
+}
+
+.timeline-empty strong {
+  color: #f8fafc;
+  font-size: 1.2rem;
+}
+
+.selected-detail-panel {
+  padding: 20px 24px;
+}
+
+.selected-detail-heading {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.detail-kicker {
+  margin: 0 0 8px;
+  color: #8fb5d8;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.selected-detail-heading h2 {
+  margin: 0;
+  font-size: 1.28rem;
+}
+
+.selected-detail-heading .detail-actions {
+  display: flex;
+  gap: 10px;
+  margin: 0;
+}
+
+.selected-detail-heading .detail-actions button {
+  width: auto;
+  min-width: 96px;
+  min-height: 44px;
+  border-radius: 5px;
+}
+
+.selected-detail-heading .detail-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(9, minmax(118px, 1fr));
+  gap: 0;
+  margin-top: 18px;
+  overflow-x: auto;
+}
+
+.detail-metric {
+  display: grid;
+  gap: 8px;
+  min-width: 128px;
+  padding: 0 22px;
+  border-left: 1px solid rgba(226, 232, 240, 0.2);
+}
+
+.detail-metric:first-child {
+  border-left: none;
+  padding-left: 0;
+}
+
+.detail-metric span {
+  color: #b9c6d3;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.detail-metric strong {
+  overflow-wrap: anywhere;
+  color: #f8fafc;
+  font-size: 1.06rem;
+}
+
+.dashboard-body .empty {
+  border-color: rgba(226, 232, 240, 0.24);
+  color: #b9c6d3;
+}
+
+.pc-management-launch {
+  display: flex;
+  justify-content: center;
+  margin-top: 18px;
+  padding-bottom: 12px;
+}
+
+.pc-management-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 54px;
+  min-width: min(100%, 340px);
+  padding: 0 22px;
+  color: #f8fafc;
+  border: 1px solid rgba(226, 232, 240, 0.28);
+  border-radius: 6px;
+  background: rgba(36, 46, 57, 0.72);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.pc-management-button:hover {
+  background: rgba(63, 78, 92, 0.86);
+}
+
+@media (max-width: 980px) {
+  .dashboard-header {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-actions {
+    grid-template-columns: 1fr 54px;
+  }
+
+  .summary-panel {
+    grid-template-columns: 1fr 1fr 0.8fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-app {
+    padding: 14px 10px 22px;
+  }
+
+  .summary-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-item {
+    padding: 14px 16px;
+    border-top: 1px solid rgba(203, 213, 225, 0.2);
+    border-left: none;
+  }
+
+  .summary-item:first-child {
+    border-top: none;
+  }
+
+  .timeline-panel > h2,
+  .timeline-panel > .form-mode,
+  .timeline-panel > .form-error {
+    margin-left: 12px;
+    margin-right: 12px;
+  }
+
+  .selected-detail-panel {
+    padding: 16px;
+  }
+
+  .selected-detail-heading {
+    grid-template-columns: 1fr;
+  }
+
+  .selected-detail-heading .detail-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .selected-detail-heading .detail-actions button {
+    width: 100%;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -823,79 +823,12 @@ button {
   font-size: 1.2rem;
 }
 
-.selected-detail-panel {
-  padding: 20px 24px;
-}
-
-.selected-detail-heading {
-  display: grid;
-  grid-template-columns: minmax(180px, 1fr) auto;
-  gap: 16px;
-  align-items: center;
-}
-
 .detail-kicker {
   margin: 0 0 8px;
   color: #8fb5d8;
   font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0.08em;
-}
-
-.selected-detail-heading h2 {
-  margin: 0;
-  font-size: 1.28rem;
-}
-
-.selected-detail-heading .detail-actions {
-  display: flex;
-  gap: 10px;
-  margin: 0;
-}
-
-.selected-detail-heading .detail-actions button {
-  width: auto;
-  min-width: 96px;
-  min-height: 44px;
-  border-radius: 5px;
-}
-
-.selected-detail-heading .detail-actions button:disabled {
-  cursor: not-allowed;
-  opacity: 0.45;
-}
-
-.detail-grid {
-  display: grid;
-  grid-template-columns: repeat(9, minmax(118px, 1fr));
-  gap: 0;
-  margin-top: 18px;
-  overflow-x: auto;
-}
-
-.detail-metric {
-  display: grid;
-  gap: 8px;
-  min-width: 128px;
-  padding: 0 22px;
-  border-left: 1px solid rgba(226, 232, 240, 0.2);
-}
-
-.detail-metric:first-child {
-  border-left: none;
-  padding-left: 0;
-}
-
-.detail-metric span {
-  color: #b9c6d3;
-  font-size: 0.85rem;
-  font-weight: 700;
-}
-
-.detail-metric strong {
-  overflow-wrap: anywhere;
-  color: #f8fafc;
-  font-size: 1.06rem;
 }
 
 .dashboard-body .empty {
@@ -966,6 +899,18 @@ button {
   border: 1px solid rgba(226, 232, 240, 0.26);
   border-radius: 5px;
   background: rgba(44, 55, 66, 0.78);
+}
+
+.dialog-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+
+.dialog-actions button {
+  min-height: 44px;
+  border-radius: 5px;
+  font-size: 0.95rem;
 }
 
 @media (max-width: 980px) {
@@ -1162,20 +1107,11 @@ button {
     display: none;
   }
 
-  .selected-detail-panel {
+  .item-name-dialog-card {
     padding: 16px;
   }
 
-  .selected-detail-heading {
+  .dialog-actions {
     grid-template-columns: 1fr;
-  }
-
-  .selected-detail-heading .detail-actions {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .selected-detail-heading .detail-actions button {
-    width: 100%;
   }
 }

--- a/style.css
+++ b/style.css
@@ -558,7 +558,7 @@ button {
       rgba(226, 232, 240, 0.12) 0,
       rgba(226, 232, 240, 0.12) 1px,
       transparent 1px,
-      transparent 168px
+      transparent var(--year-width)
     ),
     linear-gradient(90deg, rgba(17, 24, 32, 0.38), rgba(42, 55, 67, 0.26));
 }
@@ -929,6 +929,45 @@ button {
   background: rgba(63, 78, 92, 0.86);
 }
 
+.item-name-dialog {
+  width: min(420px, calc(100% - 32px));
+  padding: 0;
+  color: #f8fafc;
+  border: 1px solid rgba(226, 232, 240, 0.24);
+  border-radius: 8px;
+  background: rgba(31, 42, 53, 0.96);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+}
+
+.item-name-dialog::backdrop {
+  background: rgba(6, 10, 14, 0.62);
+}
+
+.item-name-dialog-card {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+
+.item-name-dialog-card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  overflow-wrap: anywhere;
+}
+
+.dialog-item-meta {
+  margin: 0;
+  color: #b9c6d3;
+  font-size: 0.95rem;
+}
+
+.item-name-dialog-card .ghost-button {
+  color: #f8fafc;
+  border: 1px solid rgba(226, 232, 240, 0.26);
+  border-radius: 5px;
+  background: rgba(44, 55, 66, 0.78);
+}
+
 @media (max-width: 980px) {
   .dashboard-header {
     grid-template-columns: 1fr;
@@ -945,28 +984,182 @@ button {
 
 @media (max-width: 640px) {
   .dashboard-app {
-    padding: 14px 10px 22px;
+    padding: 6px 6px 16px;
+  }
+
+  .dashboard-header {
+    gap: 6px;
+    padding-bottom: 6px;
+  }
+
+  .dashboard-title h1 {
+    font-size: 0.95rem;
+  }
+
+  .dashboard-body .subtitle {
+    display: none;
   }
 
   .summary-panel {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1.3fr 1fr 0.7fr;
+    min-height: 38px;
   }
 
   .summary-item {
-    padding: 14px 16px;
-    border-top: 1px solid rgba(203, 213, 225, 0.2);
-    border-left: none;
+    gap: 2px;
+    padding: 5px 6px;
+    border-top: none;
+    border-left: 1px solid rgba(203, 213, 225, 0.2);
   }
 
   .summary-item:first-child {
-    border-top: none;
+    border-left: none;
+  }
+
+  .summary-label {
+    font-size: 0.58rem;
+  }
+
+  .summary-item strong,
+  .summary-item:not(.summary-item-primary) strong {
+    font-size: 0.78rem;
+  }
+
+  .dashboard-actions {
+    grid-template-columns: 1fr 34px;
+    gap: 6px;
+  }
+
+  .dashboard-actions button {
+    min-height: 30px;
+    border-radius: 4px;
+    font-size: 0.72rem;
+  }
+
+  .dashboard-actions .ghost-button::before {
+    font-size: 0.98rem;
+  }
+
+  .dashboard-body .panel {
+    margin-top: 8px;
   }
 
   .timeline-panel > h2,
   .timeline-panel > .form-mode,
   .timeline-panel > .form-error {
-    margin-left: 12px;
-    margin-right: 12px;
+    margin-left: 8px;
+    margin-right: 8px;
+  }
+
+  .timeline-panel > h2 {
+    margin-top: 8px;
+    margin-bottom: 4px;
+    font-size: 0.78rem;
+  }
+
+  .timeline-panel > .form-mode,
+  .timeline-panel > .form-error {
+    margin-bottom: 4px;
+    font-size: 0.62rem;
+  }
+
+  .timeline-shell {
+    min-height: 188px;
+  }
+
+  .timeline-grid {
+    min-height: 174px;
+    padding: 30px 0;
+  }
+
+  .timeline-grid::before {
+    top: 30px;
+    bottom: 30px;
+  }
+
+  .timeline-axis {
+    height: 30px;
+  }
+
+  .timeline-year {
+    font-size: 0.68rem;
+  }
+
+  .timeline-axis-top .timeline-year {
+    top: 8px;
+  }
+
+  .timeline-axis-bottom .timeline-year {
+    bottom: 8px;
+  }
+
+  .timeline-tick {
+    height: 3px;
+  }
+
+  .timeline-tick.major {
+    height: 7px;
+  }
+
+  .timeline-current-line {
+    top: 24px;
+    bottom: 24px;
+    width: 1px;
+  }
+
+  .timeline-current-line::before,
+  .timeline-current-line::after {
+    border-right-width: 5px;
+    border-left-width: 5px;
+  }
+
+  .timeline-current-line::before {
+    top: 4px;
+    border-bottom-width: 8px;
+  }
+
+  .timeline-current-line::after {
+    bottom: 4px;
+    border-top-width: 8px;
+  }
+
+  .timeline-current-line span {
+    margin-top: 14px;
+    font-size: 0.54rem;
+  }
+
+  .timeline-row {
+    height: 40px;
+  }
+
+  .timeline-row-label {
+    gap: 4px;
+    padding: 0 5px;
+  }
+
+  .timeline-row-label strong {
+    font-size: 0.58rem;
+  }
+
+  .status-swatch {
+    width: 6px;
+    height: 6px;
+    border-radius: 2px;
+  }
+
+  .lifecycle-band {
+    top: 7px;
+    gap: 4px;
+    height: 24px;
+    min-height: 24px;
+    padding: 0 5px;
+    border-radius: 3px;
+    font-size: 0.56rem;
+  }
+
+  .band-cost,
+  .timeline-end-label {
+    display: none;
   }
 
   .selected-detail-panel {

--- a/style.css
+++ b/style.css
@@ -478,15 +478,24 @@ button {
 }
 
 .dashboard-actions {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
+  justify-content: flex-end;
 }
 
 .dashboard-actions button {
+  width: 132px;
   min-height: 58px;
+  min-width: 132px;
+  padding: 0 18px;
   border-radius: 6px;
   white-space: nowrap;
+}
+
+.dashboard-actions #logout-button {
+  width: 132px;
+  margin-top: 0;
 }
 
 .dashboard-actions .primary-button {
@@ -1141,7 +1150,7 @@ button {
   }
 
   .dashboard-actions {
-    grid-template-columns: 1fr 1fr;
+    justify-content: flex-start;
   }
 
   .summary-panel {
@@ -1193,14 +1202,20 @@ button {
   }
 
   .dashboard-actions {
-    grid-template-columns: 1fr 1fr;
     gap: 6px;
   }
 
   .dashboard-actions button {
+    width: 82px;
     min-height: 30px;
+    min-width: 82px;
+    padding: 0 10px;
     border-radius: 4px;
     font-size: 0.72rem;
+  }
+
+  .dashboard-actions #logout-button {
+    width: 82px;
   }
 
   .dashboard-actions .ghost-button::before {

--- a/style.css
+++ b/style.css
@@ -84,14 +84,27 @@ label {
 }
 
 input,
-select {
+select,
+textarea {
   width: 100%;
-  height: 44px;
   padding: 0 12px;
   border: 1px solid var(--line);
   border-radius: 10px;
   background: #fff;
   font-size: 1rem;
+}
+
+input,
+select {
+  height: 44px;
+}
+
+textarea {
+  min-height: 104px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  resize: vertical;
+  line-height: 1.6;
 }
 
 .checkbox-field {
@@ -110,7 +123,8 @@ select {
 }
 
 input:focus,
-select:focus {
+select:focus,
+textarea:focus {
   border-color: var(--primary);
   outline: 2px solid rgba(37, 99, 235, 0.2);
 }
@@ -979,6 +993,20 @@ button {
   --band-end: rgba(132, 142, 151, 0.82);
   --band-overuse-start: rgba(82, 91, 101, 0.94);
   --band-overuse-end: rgba(101, 111, 121, 0.9);
+}
+
+.category-pc-main {
+  --band-start: rgba(33, 110, 95, 0.96);
+  --band-end: rgba(49, 139, 120, 0.9);
+  --band-overuse-start: rgba(24, 84, 71, 0.98);
+  --band-overuse-end: rgba(38, 104, 90, 0.94);
+}
+
+.category-pc-sub {
+  --band-start: rgba(42, 105, 172, 0.96);
+  --band-end: rgba(73, 138, 203, 0.9);
+  --band-overuse-start: rgba(31, 78, 132, 0.98);
+  --band-overuse-end: rgba(48, 101, 164, 0.94);
 }
 
 .timeline-empty {

--- a/style.css
+++ b/style.css
@@ -512,6 +512,7 @@ button {
 }
 
 .timeline-panel > h2,
+.timeline-panel > .timeline-legend,
 .timeline-panel > .form-mode,
 .timeline-panel > .form-error {
   margin-left: 18px;
@@ -520,6 +521,47 @@ button {
 
 .timeline-panel > h2 {
   margin-top: 18px;
+}
+
+.timeline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  margin-top: 10px;
+  margin-bottom: 12px;
+  color: #c9d6e2;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.legend-band {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 3px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
+}
+
+.legend-band[class*="category-"] {
+  background: linear-gradient(90deg, var(--band-start), var(--band-end));
+}
+
+.legend-overused {
+  background: linear-gradient(
+    90deg,
+    rgba(48, 100, 189, 0.95) 0%,
+    rgba(69, 123, 214, 0.88) 48%,
+    rgba(38, 79, 153, 0.96) 48%,
+    rgba(54, 99, 179, 0.92) 100%
+  );
 }
 
 .timeline-shell {
@@ -693,12 +735,13 @@ button {
   white-space: nowrap;
 }
 
-.status-swatch {
+.category-swatch {
   flex: 0 0 auto;
   width: 14px;
   height: 14px;
   border-radius: 3px;
-  box-shadow: 0 0 12px currentColor;
+  background: linear-gradient(90deg, var(--band-start), var(--band-end));
+  box-shadow: 0 0 12px var(--band-end);
 }
 
 .lifecycle-band {
@@ -716,10 +759,23 @@ button {
   color: #f8fafc;
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 4px;
+  background: linear-gradient(90deg, var(--band-start), var(--band-end));
   font-size: 0.95rem;
   font-weight: 800;
   text-align: left;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
+}
+
+.lifecycle-band.overused::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: var(--overuse-start);
+  z-index: 0;
+  pointer-events: none;
+  background: linear-gradient(90deg, var(--band-overuse-start), var(--band-overuse-end));
+  content: "";
 }
 
 .lifecycle-band[aria-pressed="true"] {
@@ -731,16 +787,23 @@ button {
   filter: brightness(1.08);
 }
 
-.band-purchase,
+.band-name,
 .band-cost {
+  position: relative;
+  z-index: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.band-name {
+  flex: 1 1 auto;
+}
+
 .band-cost {
   flex: 0 1 auto;
+  max-width: 45%;
   text-align: right;
 }
 
@@ -772,40 +835,60 @@ button {
   color: #aeb8c2;
 }
 
-.status-swatch.status-normal {
-  background: #4b84d8;
+.category-information_device {
+  --band-start: rgba(48, 100, 189, 0.95);
+  --band-end: rgba(69, 123, 214, 0.88);
+  --band-overuse-start: rgba(38, 79, 153, 0.96);
+  --band-overuse-end: rgba(54, 99, 179, 0.92);
 }
 
-.status-swatch.status-warning {
-  background: #e2b845;
+.category-smartphone {
+  --band-start: rgba(30, 150, 136, 0.95);
+  --band-end: rgba(52, 184, 166, 0.88);
+  --band-overuse-start: rgba(22, 116, 106, 0.96);
+  --band-overuse-end: rgba(38, 145, 132, 0.92);
 }
 
-.status-swatch.status-danger {
-  background: #db6f42;
+.category-audio_visual {
+  --band-start: rgba(121, 81, 190, 0.95);
+  --band-end: rgba(148, 105, 214, 0.88);
+  --band-overuse-start: rgba(92, 62, 150, 0.96);
+  --band-overuse-end: rgba(116, 80, 174, 0.92);
 }
 
-.status-swatch.status-ended {
-  background: #818b95;
+.category-air_conditioning {
+  --band-start: rgba(31, 132, 172, 0.95);
+  --band-end: rgba(72, 169, 204, 0.88);
+  --band-overuse-start: rgba(24, 101, 133, 0.96);
+  --band-overuse-end: rgba(48, 135, 164, 0.92);
 }
 
-.lifecycle-band.status-normal {
-  color: #f8fafc;
-  background: linear-gradient(90deg, rgba(48, 100, 189, 0.95), rgba(69, 123, 214, 0.88));
+.category-living_appliance {
+  --band-start: rgba(82, 141, 66, 0.95);
+  --band-end: rgba(112, 170, 92, 0.88);
+  --band-overuse-start: rgba(63, 108, 50, 0.96);
+  --band-overuse-end: rgba(86, 132, 70, 0.92);
 }
 
-.lifecycle-band.status-warning {
-  color: #f8fafc;
-  background: linear-gradient(90deg, rgba(190, 143, 33, 0.95), rgba(224, 185, 71, 0.9));
+.category-cooking_appliance {
+  --band-start: rgba(190, 143, 33, 0.95);
+  --band-end: rgba(224, 185, 71, 0.9);
+  --band-overuse-start: rgba(159, 116, 24, 0.96);
+  --band-overuse-end: rgba(190, 150, 48, 0.92);
 }
 
-.lifecycle-band.status-danger {
-  color: #f8fafc;
-  background: linear-gradient(90deg, rgba(190, 91, 47, 0.96), rgba(218, 111, 66, 0.9));
+.category-beauty_health {
+  --band-start: rgba(190, 82, 128, 0.95);
+  --band-end: rgba(218, 110, 155, 0.88);
+  --band-overuse-start: rgba(151, 60, 98, 0.96);
+  --band-overuse-end: rgba(178, 82, 120, 0.92);
 }
 
-.lifecycle-band.status-ended {
-  color: #f8fafc;
-  background: linear-gradient(90deg, rgba(107, 117, 127, 0.9), rgba(132, 142, 151, 0.82));
+.category-other {
+  --band-start: rgba(107, 117, 127, 0.9);
+  --band-end: rgba(132, 142, 151, 0.82);
+  --band-overuse-start: rgba(82, 91, 101, 0.94);
+  --band-overuse-end: rgba(101, 111, 121, 0.9);
 }
 
 .timeline-empty {
@@ -1086,7 +1169,7 @@ button {
     font-size: 0.58rem;
   }
 
-  .status-swatch {
+  .category-swatch {
     width: 6px;
     height: 6px;
     border-radius: 2px;

--- a/style.css
+++ b/style.css
@@ -94,6 +94,21 @@ select {
   font-size: 1rem;
 }
 
+.checkbox-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  margin-top: 4px;
+  font-weight: 700;
+}
+
+.checkbox-field input {
+  width: 18px;
+  height: 18px;
+  padding: 0;
+}
+
 input:focus,
 select:focus {
   border-color: var(--primary);
@@ -526,6 +541,10 @@ button {
 }
 
 .dashboard-actions #logout-button::before {
+  display: none;
+}
+
+.dashboard-actions #back-button::before {
   display: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -303,6 +303,32 @@ button {
   color: var(--primary-strong);
 }
 
+.calculation-result {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #f7faff;
+}
+
+.calculation-result div {
+  display: grid;
+  gap: 4px;
+}
+
+.calculation-result span {
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.calculation-result strong {
+  color: var(--primary-strong);
+  font-size: 1.2rem;
+}
+
 .card-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -362,6 +388,10 @@ button {
 }
 
 @media (max-width: 520px) {
+  .calculation-result {
+    grid-template-columns: 1fr;
+  }
+
   .additional-cost-row {
     grid-template-columns: 1fr;
   }
@@ -449,7 +479,7 @@ button {
 
 .dashboard-actions {
   display: grid;
-  grid-template-columns: minmax(150px, 1fr) 54px;
+  grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
 
@@ -470,7 +500,7 @@ button {
 
 .dashboard-actions .ghost-button {
   overflow: hidden;
-  color: transparent;
+  color: #f8fafc;
   border: 1px solid rgba(226, 232, 240, 0.28);
   background: rgba(36, 46, 57, 0.58);
   position: relative;
@@ -484,6 +514,10 @@ button {
   place-items: center;
   color: #e5edf5;
   font-size: 1.45rem;
+}
+
+.dashboard-actions #logout-button::before {
+  display: none;
 }
 
 .dashboard-body .panel {
@@ -562,6 +596,11 @@ button {
     rgba(38, 79, 153, 0.96) 48%,
     rgba(54, 99, 179, 0.92) 100%
   );
+}
+
+.legend-unused {
+  background: rgba(255, 255, 255, 0.04);
+  border-style: dashed;
 }
 
 .timeline-shell {
@@ -766,6 +805,29 @@ button {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
+.post-end-band {
+  position: absolute;
+  top: 12px;
+  z-index: 2;
+  height: 48px;
+  min-height: 48px;
+  padding: 0;
+  border: 1px dashed rgba(148, 163, 184, 0.42);
+  border-left: 0;
+  border-radius: 0 4px 4px 0;
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.post-end-band[aria-pressed="true"] {
+  outline: 2px solid rgba(255, 255, 255, 0.42);
+  outline-offset: 2px;
+}
+
+.post-end-band:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
 .lifecycle-band.overused::after {
   position: absolute;
   top: 0;
@@ -921,6 +983,8 @@ button {
 
 .pc-management-launch {
   display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
   justify-content: center;
   margin-top: 18px;
   padding-bottom: 12px;
@@ -939,10 +1003,85 @@ button {
   background: rgba(36, 46, 57, 0.72);
   font-weight: 800;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .pc-management-button:hover {
   background: rgba(63, 78, 92, 0.86);
+}
+
+.help-button {
+  min-width: 120px;
+}
+
+.help-dialog {
+  width: min(720px, calc(100% - 32px));
+  max-height: min(760px, calc(100% - 32px));
+  padding: 0;
+  overflow: hidden;
+  color: #f8fafc;
+  border: 1px solid rgba(226, 232, 240, 0.24);
+  border-radius: 8px;
+  background: rgba(31, 42, 53, 0.97);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.42);
+}
+
+.help-dialog::backdrop {
+  background: rgba(6, 10, 14, 0.62);
+}
+
+.help-dialog-card {
+  display: grid;
+  gap: 18px;
+  max-height: inherit;
+  padding: 22px;
+  overflow: auto;
+}
+
+.help-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.help-dialog-header h2,
+.help-section h3,
+.help-section p {
+  margin: 0;
+}
+
+.help-dialog-header h2 {
+  font-size: 1.35rem;
+}
+
+.help-dialog-header .ghost-button {
+  min-height: 38px;
+  padding: 0 16px;
+  color: #f8fafc;
+  border: 1px solid rgba(226, 232, 240, 0.26);
+  border-radius: 5px;
+  background: rgba(44, 55, 66, 0.78);
+}
+
+.help-section {
+  display: grid;
+  gap: 10px;
+}
+
+.help-section h3 {
+  color: #e5edf5;
+  font-size: 1rem;
+}
+
+.help-section p {
+  color: #d4dee8;
+  font-size: 0.95rem;
+  line-height: 1.8;
+}
+
+.help-legend {
+  margin: 0;
 }
 
 .item-name-dialog {
@@ -1002,7 +1141,7 @@ button {
   }
 
   .dashboard-actions {
-    grid-template-columns: 1fr 54px;
+    grid-template-columns: 1fr 1fr;
   }
 
   .summary-panel {
@@ -1054,7 +1193,7 @@ button {
   }
 
   .dashboard-actions {
-    grid-template-columns: 1fr 34px;
+    grid-template-columns: 1fr 1fr;
     gap: 6px;
   }
 
@@ -1185,9 +1324,45 @@ button {
     font-size: 0.56rem;
   }
 
+  .post-end-band {
+    top: 7px;
+    height: 24px;
+    min-height: 24px;
+    border-radius: 0 3px 3px 0;
+  }
+
   .band-cost,
   .timeline-end-label {
     display: none;
+  }
+
+  .pc-management-launch {
+    gap: 6px;
+    margin-top: 10px;
+  }
+
+  .pc-management-button {
+    min-height: 40px;
+    min-width: 0;
+    padding: 0 12px;
+    font-size: 0.78rem;
+  }
+
+  .help-button {
+    min-width: 86px;
+  }
+
+  .help-dialog-card {
+    gap: 14px;
+    padding: 16px;
+  }
+
+  .help-dialog-header h2 {
+    font-size: 1.1rem;
+  }
+
+  .help-section p {
+    font-size: 0.86rem;
   }
 
   .item-name-dialog-card {


### PR DESCRIPTION
## Summary
- 一覧画面をダークテーマのライフサイクルタイムラインUIへ刷新
- 購入日と予定耐用年数から横スクロール可能な帯グラフを表示
- 現在位置ライン、状態色、上部サマリー、選択中商品の詳細パネルを追加
- パソコン管理への導線をタイムラインとは分け、画面下部の独立ボタンに移動
- Cursor/VS Code の実行設定を `list.html` 起動に変更

## Validation
- `node --check js/list.js`
- `node --check service-worker.js`
- `.vscode/launch.json` / `.vscode/tasks.json` のJSON確認
