### PR TITLE
Tune login screen visuals

### DIFF
--- a/style.css
+++ b/style.css
@@ -226,12 +226,18 @@ button {
 
 .login-brand {
   align-self: start;
-  color: #17202a;
-  text-shadow: 0 1px 18px rgba(255, 255, 255, 0.72);
+  justify-self: center;
+  width: min(75vw, 420px);
+  color: #fff;
+  text-align: center;
+  text-shadow:
+    0 1px 1px rgba(17, 24, 39, 0.9),
+    0 3px 8px rgba(17, 24, 39, 0.62),
+    0 10px 24px rgba(17, 24, 39, 0.45);
 }
 
 .login-brand h1 {
-  font-size: clamp(1.55rem, 7vw, 2.35rem);
+  font-size: clamp(2.2rem, 11vw, 4.2rem);
   font-weight: 900;
 }
 
@@ -243,28 +249,30 @@ button {
   width: min(100%, 420px);
   margin: 18px auto 0;
   padding: 16px;
-  color: #18212c;
-  border: 1px solid rgba(255, 255, 255, 0.72);
+  color: #111827;
+  border: 1px solid rgba(255, 255, 255, 0.46);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.82);
-  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.28);
-  backdrop-filter: blur(16px);
+  background: rgba(255, 255, 255, 0.42);
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.32);
+  backdrop-filter: blur(8px) saturate(1.12);
 }
 
 .auth-panel h2 {
   margin-bottom: 0;
   font-size: 1.18rem;
+  text-shadow: 0 1px 12px rgba(255, 255, 255, 0.92);
 }
 
 .auth-panel label {
   margin-top: 2px;
-  color: #263241;
+  color: #111827;
+  text-shadow: 0 1px 12px rgba(255, 255, 255, 0.92);
 }
 
 .auth-panel input {
   height: 50px;
-  border-color: rgba(83, 98, 115, 0.36);
-  background: rgba(255, 255, 255, 0.94);
+  border-color: rgba(17, 24, 39, 0.22);
+  background: rgba(255, 255, 255, 0.7);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
 }
 
@@ -297,7 +305,7 @@ button {
 .auth-panel .ghost-button {
   color: #17202a;
   border-color: rgba(83, 98, 115, 0.28);
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.68);
 }
 
 .card-list {
@@ -556,7 +564,6 @@ button {
   }
 
   .login-brand {
-    justify-self: start;
     margin-bottom: 22px;
   }
 


### PR DESCRIPTION
## Summary
- Make the login title larger, centered, and easier to read on mobile
- Increase transparency of the login panel while keeping form fields readable
- Remove the red glow from the title shadow

## Validation
- Reviewed CSS diff for the login screen only