### PR TITLE
[codex] Remove signup and add local restore export

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -12,7 +12,6 @@ import {
 } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-firestore.js";
 import {
   getAuth,
-  createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
   signOut,
   onAuthStateChanged,
@@ -234,6 +233,49 @@ export async function createLocalBackupData() {
   };
 }
 
+function toBackupValue(value) {
+  if (!value) return value;
+  if (typeof value.toMillis === "function") return value.toMillis();
+  if (Array.isArray(value)) return value.map(toBackupValue);
+  if (typeof value !== "object") return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entryValue]) => [key, toBackupValue(entryValue)])
+  );
+}
+
+export async function createFirebaseLocalBackupData(uid) {
+  if (!uid) {
+    throw new Error("Firebaseデータの取得に必要なユーザー情報がありません。");
+  }
+
+  const snapshot = await getDocs(userItemsCollectionRef(uid));
+  const durableGoodsItems = [];
+  const pcItems = [];
+
+  snapshot.forEach((documentSnapshot) => {
+    const record = toBackupValue({
+      id: documentSnapshot.id,
+      ...documentSnapshot.data(),
+    });
+
+    if (isPcManagementItem(record)) {
+      pcItems.push(record);
+      return;
+    }
+
+    durableGoodsItems.push(normalizeStoredItem(record));
+  });
+
+  return {
+    app: LOCAL_BACKUP_APP_NAME,
+    version: LOCAL_BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    durableGoodsItems: sortStoredItems(durableGoodsItems),
+    pcItems,
+  };
+}
+
 function validateBackupRecordIds(records, label) {
   for (const record of records) {
     if (!record || typeof record !== "object" || !record.id) {
@@ -277,11 +319,6 @@ export function onAuthChanged(callback) {
 export async function login(email, password) {
   exitLocalMode();
   return signInWithEmailAndPassword(auth, email, password);
-}
-
-export async function signup(email, password) {
-  exitLocalMode();
-  return createUserWithEmailAndPassword(auth, email, password);
 }
 
 export async function logout() {

--- a/js/form.js
+++ b/js/form.js
@@ -240,8 +240,13 @@ form.addEventListener("submit", async (event) => {
   event.preventDefault();
   formError.textContent = "";
 
+  if (!state.editingId || !idInput.value) {
+    formError.textContent = "新規登録は無効です。一覧から既存データを選択して編集してください。";
+    return;
+  }
+
   const item = {
-    id: idInput.value || createId(),
+    id: idInput.value,
     isUpdate: Boolean(state.editingId),
     name: nameInput.value.trim(),
     model: modelInput.dataset.encodedModel || modelInput.value.trim(),
@@ -280,10 +285,7 @@ onAuthChanged(async (user) => {
   }
 
   if (!state.editingId) {
-    submitButton.textContent = "登録する";
-    cancelButton.hidden = true;
-    updateEndedUseStyle();
-    renderAdditionalCosts([]);
+    window.location.href = "list.html";
     return;
   }
 

--- a/js/list.js
+++ b/js/list.js
@@ -4,6 +4,7 @@ import {
   loadItems,
   removeItem,
   createLocalBackupData,
+  createFirebaseLocalBackupData,
   parseLocalBackupText,
   restoreLocalBackupData,
   calculateMonthlyCost,
@@ -21,12 +22,12 @@ const authError = document.getElementById("auth-error");
 const logoutButton = document.getElementById("logout-button");
 const backupButton = document.getElementById("backup-button");
 const restoreButton = document.getElementById("restore-button");
-const createButton = document.getElementById("create-button");
 const categoryFilter = document.getElementById("category-filter");
 const itemList = document.getElementById("item-list");
 const helpButton = document.getElementById("help-button");
 const helpDialog = document.getElementById("help-dialog");
 const helpCloseButton = document.getElementById("help-close-button");
+const firebaseLocalBackupButton = document.getElementById("firebase-local-backup-button");
 
 const summaryMonthlyCost = document.getElementById("summary-monthly-cost");
 const summaryPurchaseTotal = document.getElementById("summary-purchase-total");
@@ -470,12 +471,6 @@ renderLoadingTimeline();
 renderCategoryFilter();
 syncLocalModeUi();
 
-if (createButton) {
-  createButton.addEventListener("click", () => {
-    window.location.href = "form.html";
-  });
-}
-
 if (categoryFilter) {
   categoryFilter.addEventListener("click", (event) => {
     const target = event.target;
@@ -515,12 +510,17 @@ function backupFileName() {
   return `月額家電簿-backup-${dateText}.json`;
 }
 
-function downloadBackupFile(backup) {
+function localRestoreFileName() {
+  const dateText = new Date().toISOString().slice(0, 10);
+  return `月額家電簿-local-restore-${dateText}.json`;
+}
+
+function downloadBackupFile(backup, fileName = backupFileName()) {
   const blob = new Blob([JSON.stringify(backup, null, 2)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  link.download = backupFileName();
+  link.download = fileName;
   document.body.appendChild(link);
   link.click();
   link.remove();
@@ -541,6 +541,29 @@ if (backupButton) {
       authError.textContent = error?.message || "バックアップの保存に失敗しました。";
     } finally {
       backupButton.disabled = false;
+    }
+  });
+}
+
+if (firebaseLocalBackupButton) {
+  firebaseLocalBackupButton.addEventListener("click", async () => {
+    authError.textContent = "";
+    if (isLocalMode()) {
+      authError.textContent = "Firebase保存データのファイル作成は、通常ログイン時のみ使用できます。";
+      return;
+    }
+    if (!state.uid) {
+      authError.textContent = "Firebaseデータの取得に必要なログイン情報がありません。";
+      return;
+    }
+
+    try {
+      firebaseLocalBackupButton.disabled = true;
+      downloadBackupFile(await createFirebaseLocalBackupData(state.uid), localRestoreFileName());
+    } catch (error) {
+      authError.textContent = firebaseErrorMessage(error, "ローカル保存用ファイルの作成に失敗しました。");
+    } finally {
+      firebaseLocalBackupButton.disabled = false;
     }
   });
 }

--- a/js/login.js
+++ b/js/login.js
@@ -1,6 +1,5 @@
 import {
   login,
-  signup,
   onAuthChanged,
   enterLocalMode,
   isLocalMode,
@@ -15,17 +14,19 @@ const authError = document.getElementById("auth-error");
 const emailInput = document.getElementById("auth-email");
 const passwordInput = document.getElementById("auth-password");
 const loginButton = document.getElementById("login-button");
-const signupButton = document.getElementById("signup-button");
 const localModeButton = document.getElementById("local-mode-button");
 const localModeDialog = document.getElementById("local-mode-dialog");
 const localModeStartButton = document.getElementById("local-mode-start-button");
 const localModeCancelButton = document.getElementById("local-mode-cancel-button");
 const hideLocalModeWarningInput = document.getElementById("hide-local-mode-warning");
 
+function setButtonDisabled(button, disabled) {
+  if (button) button.disabled = disabled;
+}
+
 function setButtonsDisabled(disabled) {
-  loginButton.disabled = disabled;
-  signupButton.disabled = disabled;
-  localModeButton.disabled = disabled;
+  setButtonDisabled(loginButton, disabled);
+  setButtonDisabled(localModeButton, disabled);
 }
 
 function getCredentials() {
@@ -53,28 +54,6 @@ loginButton.addEventListener("click", async () => {
   }
 });
 
-signupButton.addEventListener("click", async () => {
-  authError.textContent = "";
-  const { email, password } = getCredentials();
-  if (!email || !password) {
-    authError.textContent = "メールアドレスとパスワードを入力してください。";
-    return;
-  }
-  if (password.length < 6) {
-    authError.textContent = "パスワードは6文字以上で入力してください。";
-    return;
-  }
-  try {
-    setButtonsDisabled(true);
-    await signup(email, password);
-    window.location.href = "list.html";
-  } catch (error) {
-    authError.textContent = firebaseErrorMessage(error, "新規登録に失敗しました。");
-  } finally {
-    setButtonsDisabled(false);
-  }
-});
-
 function shouldShowLocalModeWarning() {
   return storageGetItem(LOCAL_WARNING_DISMISSED_KEY) !== "true";
 }
@@ -95,23 +74,23 @@ async function startLocalMode() {
   }
 }
 
-localModeButton.addEventListener("click", async () => {
+localModeButton?.addEventListener("click", async () => {
   if (!shouldShowLocalModeWarning() || !localModeDialog) {
     await startLocalMode();
     return;
   }
 
-  hideLocalModeWarningInput.checked = false;
+  if (hideLocalModeWarningInput) hideLocalModeWarningInput.checked = false;
   localModeDialog.showModal();
 });
 
-localModeStartButton.addEventListener("click", async () => {
-  localModeDialog.close();
+localModeStartButton?.addEventListener("click", async () => {
+  localModeDialog?.close();
   await startLocalMode();
 });
 
-localModeCancelButton.addEventListener("click", () => {
-  localModeDialog.close();
+localModeCancelButton?.addEventListener("click", () => {
+  localModeDialog?.close();
 });
 
 onAuthChanged((user) => {

--- a/list.html
+++ b/list.html
@@ -39,7 +39,6 @@
           </div>
         </section>
         <div class="dashboard-actions">
-          <button id="create-button" type="button" class="primary-button">新規登録</button>
           <div id="category-filter" class="category-filter" aria-label="分類フィルター"></div>
         </div>
       </header>
@@ -87,6 +86,12 @@
           <p>単に購入履歴を残すだけでなく、使用期間を年表で確認することで、買い替え時期の目安や、予定より早く使えなくなったものを把握しやすくします。</p>
           <p>月額換算のコストや使用終了後の期間を確認することで、次回購入時の判断材料と月額コストの把握をすることに活用できます。</p>
         </section>
+
+        <div class="help-dialog-actions">
+          <button id="firebase-local-backup-button" type="button" class="primary-button">
+            ローカル保存用ファイル作成ボタン
+          </button>
+        </div>
       </article>
     </dialog>
 

--- a/login.html
+++ b/login.html
@@ -25,7 +25,6 @@
         <p id="auth-error" class="form-error"></p>
         <div class="form-actions auth-actions">
           <button id="login-button" class="primary-button" type="button">ログイン</button>
-          <button id="signup-button" class="ghost-button" type="button">新規登録</button>
           <button id="local-mode-button" class="ghost-button" type="button">ローカル保存</button>
         </div>
       </section>

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -43,7 +43,6 @@ const elements = {
   summaryTotal: document.getElementById("summary-total"),
   summaryMonthly: document.getElementById("summary-monthly"),
   authError: document.getElementById("auth-error"),
-  createButton: document.getElementById("create-button"),
   categoryFilter: document.getElementById("category-filter"),
   hiddenButton: document.getElementById("hidden-button"),
   backButton: document.getElementById("back-button"),
@@ -611,7 +610,7 @@ function validatePcItem(item) {
 function collectPcItem() {
   const existingItem = state.items.find((item) => item.id === state.editingId);
   return normalizePcPartItem({
-    id: elements.id.value || createId(),
+    id: elements.id.value,
     partName: elements.partName.value.trim(),
     modelNumber: elements.modelNumber.value.trim(),
     pcName: elements.pcName.value,
@@ -727,6 +726,11 @@ if (elements.form) {
       return;
     }
 
+    if (!state.editingId || !elements.id.value) {
+      elements.formError.textContent = "新規登録は無効です。一覧から既存データを選択して編集してください。";
+      return;
+    }
+
     const item = collectPcItem();
     const validation = validatePcItem(item);
     if (validation) {
@@ -750,12 +754,6 @@ if (elements.form) {
   });
   elements.toListButton.addEventListener("click", () => {
     window.location.href = "index.html";
-  });
-}
-
-if (elements.createButton) {
-  elements.createButton.addEventListener("click", () => {
-    window.location.href = "form.html";
   });
 }
 
@@ -887,12 +885,7 @@ onAuthChanged(async (user) => {
     }
 
     if (!state.editingId) {
-      elements.submitButton.textContent = "登録する";
-      elements.cancelButton.hidden = true;
-      elements.pcName.value = "main";
-      elements.yearsOfUse.value = elements.yearsOfUse.value || "5";
-      updateEndedUseStyle();
-      updateCalculationResult();
+      window.location.href = "index.html";
       return;
     }
 

--- a/pc-management/index.html
+++ b/pc-management/index.html
@@ -35,7 +35,6 @@
           </div>
         </section>
         <div class="dashboard-actions">
-          <button id="create-button" type="button" class="primary-button">新規登録</button>
           <div id="category-filter" class="category-filter" aria-label="分類フィルター"></div>
         </div>
       </header>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v49";
+const CACHE_NAME = "durable-goods-pwa-v51";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",

--- a/style.css
+++ b/style.css
@@ -281,7 +281,7 @@ button {
 }
 
 .auth-panel .auth-actions {
-  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
   margin-top: 2px;
 }
@@ -1397,6 +1397,19 @@ button {
 
 .help-legend {
   margin: 0;
+}
+
+.help-dialog-actions {
+  display: grid;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.help-dialog-actions .primary-button {
+  width: 100%;
+  min-height: 46px;
+  padding: 0 16px;
+  border-radius: 5px;
 }
 
 .item-name-dialog {


### PR DESCRIPTION
## Summary
- Remove signup entry points from the login and list workflows.
- Guard direct form access so new records cannot be created from removed routes.
- Add a help-dialog button that exports Firebase data as a local-restore JSON file.
- Bump the service worker cache name so updated assets are picked up.

## Validation
- `node --check .\js\common.js`
- `node --check .\js\form.js`
- `node --check .\js\list.js`
- `node --check .\js\login.js`
- `node --check .\pc-management\app.js`
- `node --check .\service-worker.js`
- `git diff --check`