### PR TITLE
[codex] Hide Firebase export in local mode

### DIFF
--- a/js/list.js
+++ b/js/list.js
@@ -275,6 +275,7 @@ function syncLocalModeUi() {
   }
   if (backupButton) backupButton.hidden = !localMode;
   if (restoreButton) restoreButton.hidden = !localMode;
+  if (firebaseLocalBackupButton) firebaseLocalBackupButton.hidden = localMode;
 }
 
 function renderEmptyTimeline() {


### PR DESCRIPTION
## Summary
- Hide the Firebase-to-local restore export button while the app is in local storage mode.
- Keep the export button visible only for Firebase-backed sessions.

## Validation
- `node --check .\js\list.js`
- `git diff --check`