### PR TITLE
[codex] 耐用年数・単価の参照データを追加

### DIFF
--- a/form.html
+++ b/form.html
@@ -29,12 +29,20 @@
           <input id="model" type="text" autocomplete="off" required />
           <label for="category">分類</label>
           <select id="category" required></select>
+          <label for="asset-reference-item">耐久消費財品目</label>
+          <select id="asset-reference-item"></select>
           <label for="purchase-date">購入日</label>
           <input id="purchase-date" type="date" required />
           <label for="purchase-price">購入価格（円）</label>
-          <input id="purchase-price" type="number" inputmode="numeric" min="0" step="1" required />
+          <div class="reference-input-row">
+            <input id="purchase-price" type="number" inputmode="numeric" min="0" step="1" required />
+            <span id="unit-price-reference" class="reference-hint" aria-live="polite"></span>
+          </div>
           <label for="years-of-use">使用年数（年）</label>
-          <input id="years-of-use" type="number" inputmode="numeric" min="1" step="1" required />
+          <div class="reference-input-row">
+            <input id="years-of-use" type="number" inputmode="numeric" min="1" step="1" required />
+            <span id="useful-life-reference" class="reference-hint" aria-live="polite"></span>
+          </div>
           <label for="end-of-use-date">使用終了日</label>
           <input id="end-of-use-date" type="date" />
 

--- a/js/common.js
+++ b/js/common.js
@@ -31,6 +31,9 @@ const LOCAL_DB_NAME = "monthlyApplianceBookLocal";
 const LOCAL_DB_VERSION = 1;
 const LOCAL_BACKUP_APP_NAME = "月額家電簿";
 const LOCAL_BACKUP_VERSION = 1;
+const LOCAL_ASSET_REFERENCE_KEY = "monthlyApplianceBook.assetReferenceData";
+const ASSET_REFERENCE_DOC_ID = "__assetReferenceData";
+const ASSET_REFERENCE_SOURCE_TYPE = "assetReferenceData";
 export const CATEGORY_OPTIONS = [
   { value: "information_device", label: "情報機器" },
   { value: "smartphone", label: "スマホ" },
@@ -218,6 +221,7 @@ export async function createLocalBackupData() {
     exportedAt: new Date().toISOString(),
     durableGoodsItems: await loadLocalRecords(LOCAL_DURABLE_ITEMS_STORE),
     pcItems: await loadLocalRecords(LOCAL_PC_ITEMS_STORE),
+    assetReferenceData: loadLocalAssetReferenceBackupData(),
   };
 }
 
@@ -229,6 +233,55 @@ function toBackupValue(value) {
 
   return Object.fromEntries(
     Object.entries(value).map(([key, entryValue]) => [key, toBackupValue(entryValue)])
+  );
+}
+
+function userReferenceDocRef(uid) {
+  return doc(db, "users", uid, ITEMS_COLLECTION, ASSET_REFERENCE_DOC_ID);
+}
+
+function normalizeAssetReferenceBackupData(value) {
+  if (!value) return null;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("参照データのバックアップ形式が正しくありません。");
+  }
+  if (!Array.isArray(value.items)) {
+    throw new Error("参照データのバックアップに品目一覧が含まれていません。");
+  }
+  return {
+    source: value.source && typeof value.source === "object" && !Array.isArray(value.source) ? value.source : {},
+    importedAt: value.importedAt ?? null,
+    items: value.items,
+  };
+}
+
+function loadLocalAssetReferenceBackupData() {
+  const value = storageGetItem(LOCAL_ASSET_REFERENCE_KEY);
+  if (!value) return null;
+  try {
+    return normalizeAssetReferenceBackupData(JSON.parse(value));
+  } catch (_error) {
+    return null;
+  }
+}
+
+async function loadFirebaseAssetReferenceBackupData(uid) {
+  const snapshot = await getDoc(userReferenceDocRef(uid));
+  if (!snapshot.exists()) return null;
+  const data = snapshot.data();
+  if (data.sourceType !== ASSET_REFERENCE_SOURCE_TYPE) return null;
+  return normalizeAssetReferenceBackupData(toBackupValue(data));
+}
+
+function restoreLocalAssetReferenceBackupData(backup) {
+  if (!Object.hasOwn(backup, "assetReferenceData")) return;
+  if (!backup.assetReferenceData) {
+    storageRemoveItem(LOCAL_ASSET_REFERENCE_KEY);
+    return;
+  }
+  storageSetItem(
+    LOCAL_ASSET_REFERENCE_KEY,
+    JSON.stringify(normalizeAssetReferenceBackupData(backup.assetReferenceData))
   );
 }
 
@@ -251,6 +304,7 @@ export async function createFirebaseLocalBackupData(uid) {
       pcItems.push(record);
       return;
     }
+    if (record.sourceType === ASSET_REFERENCE_SOURCE_TYPE) return;
 
     durableGoodsItems.push(normalizeStoredItem(record));
   });
@@ -261,6 +315,7 @@ export async function createFirebaseLocalBackupData(uid) {
     exportedAt: new Date().toISOString(),
     durableGoodsItems: sortStoredItems(durableGoodsItems),
     pcItems,
+    assetReferenceData: await loadFirebaseAssetReferenceBackupData(uid),
   };
 }
 
@@ -292,12 +347,16 @@ export function parseLocalBackupText(text) {
 
   validateBackupRecordIds(backup.durableGoodsItems, "通常家電");
   validateBackupRecordIds(backup.pcItems, "パソコン管理");
+  if (Object.hasOwn(backup, "assetReferenceData")) {
+    normalizeAssetReferenceBackupData(backup.assetReferenceData);
+  }
   return backup;
 }
 
 export async function restoreLocalBackupData(backup) {
   await replaceLocalRecords(LOCAL_DURABLE_ITEMS_STORE, backup.durableGoodsItems);
   await replaceLocalRecords(LOCAL_PC_ITEMS_STORE, backup.pcItems);
+  restoreLocalAssetReferenceBackupData(backup);
 }
 
 export function onAuthChanged(callback) {
@@ -453,6 +512,7 @@ function normalizeStoredItem(item) {
     name: item.name ?? "",
     model: item.model ?? "",
     category: normalizeCategory(item.category),
+    assetReferenceItemCode: String(item.assetReferenceItemCode ?? ""),
     sourceType: item.sourceType ?? "",
     purchaseDate: item.purchaseDate ?? "",
     purchasePrice: Number(item.purchasePrice ?? 0),
@@ -478,13 +538,16 @@ function sortStoredItems(items) {
 
 export async function loadItems(uid) {
   if (isLocalMode()) {
-    return sortStoredItems((await loadLocalRecords(LOCAL_DURABLE_ITEMS_STORE)).map(normalizeStoredItem));
+    return sortStoredItems((await loadLocalRecords(LOCAL_DURABLE_ITEMS_STORE))
+      .filter((item) => item?.sourceType !== ASSET_REFERENCE_SOURCE_TYPE)
+      .map(normalizeStoredItem));
   }
 
   const snapshot = await getDocs(userItemsCollectionRef(uid));
   const items = [];
   snapshot.forEach((documentSnapshot) => {
     const data = documentSnapshot.data();
+    if (data.sourceType === ASSET_REFERENCE_SOURCE_TYPE) return;
     items.push(normalizeStoredItem({
       id: documentSnapshot.id,
       ...data,
@@ -518,6 +581,7 @@ export async function saveItem(uid, item) {
       name: item.name,
       model: item.model,
       category: item.category,
+      assetReferenceItemCode: item.assetReferenceItemCode,
       purchaseDate: item.purchaseDate,
       purchasePrice: item.purchasePrice,
       yearsOfUse: item.yearsOfUse,
@@ -534,6 +598,7 @@ export async function saveItem(uid, item) {
     name: item.name,
     model: item.model,
     category: normalizeCategory(item.category),
+    assetReferenceItemCode: String(item.assetReferenceItemCode ?? ""),
     purchaseDate: item.purchaseDate,
     purchasePrice: item.purchasePrice,
     yearsOfUse: item.yearsOfUse,

--- a/js/form.js
+++ b/js/form.js
@@ -14,6 +14,9 @@ import {
 } from "./common.js";
 import { isLocalMode } from "./platform/local-db.js";
 import { onAuthChanged, registerServiceWorker } from "./services/auth.js";
+import {
+  loadAssetReferenceData,
+} from "./services/asset-reference.js";
 import { loadItem, saveItem } from "./storage/durable-items/service.js";
 
 const EDITING_ITEM_ID_KEY = "monthlyApplianceBook.editingItemId";
@@ -30,9 +33,12 @@ const idInput = document.getElementById("item-id");
 const nameInput = document.getElementById("name");
 const modelInput = document.getElementById("model");
 const categoryInput = document.getElementById("category");
+const assetReferenceItemInput = document.getElementById("asset-reference-item");
 const purchaseDateInput = document.getElementById("purchase-date");
 const purchasePriceInput = document.getElementById("purchase-price");
 const yearsOfUseInput = document.getElementById("years-of-use");
+const unitPriceReference = document.getElementById("unit-price-reference");
+const usefulLifeReference = document.getElementById("useful-life-reference");
 const endOfUseDateInput = document.getElementById("end-of-use-date");
 const hideFromTimelineInput = document.getElementById("hide-from-timeline");
 const addCostButton = document.getElementById("add-cost-button");
@@ -105,7 +111,48 @@ function showHiddenTimelineNoticeDialog() {
 const state = {
   uid: null,
   editingId: new URLSearchParams(window.location.search).get("id") || sessionStorageGetItem(EDITING_ITEM_ID_KEY),
+  assetReferenceData: null,
 };
+
+function updateAssetReferenceDisplay() {
+  if (!unitPriceReference || !usefulLifeReference) return;
+  const selectedCode = assetReferenceItemInput?.value ?? "";
+  const item = state.assetReferenceData?.items?.find((entry) => entry.code === selectedCode);
+
+  if (!item) {
+    unitPriceReference.textContent = "";
+    usefulLifeReference.textContent = "";
+    return;
+  }
+
+  unitPriceReference.textContent = `参考単価: ${formatCurrency(item.unitPrice)}`;
+  usefulLifeReference.textContent = `耐用年数: ${item.usefulLifeYears}年`;
+}
+
+function populateAssetReferenceSelect() {
+  if (!assetReferenceItemInput) return;
+
+  const currentValue = assetReferenceItemInput.value;
+  assetReferenceItemInput.innerHTML = "";
+
+  const emptyOption = document.createElement("option");
+  emptyOption.value = "";
+  emptyOption.textContent = "なし";
+  assetReferenceItemInput.appendChild(emptyOption);
+
+  for (const item of state.assetReferenceData?.items ?? []) {
+    const option = document.createElement("option");
+    option.value = item.code;
+    option.textContent = `${item.code} ${item.label}`;
+    assetReferenceItemInput.appendChild(option);
+  }
+
+  assetReferenceItemInput.value = [...assetReferenceItemInput.options].some((option) => option.value === currentValue)
+    ? currentValue
+    : "";
+  updateAssetReferenceDisplay();
+}
+
 function populateCategorySelect() {
   categoryInput.innerHTML = "";
   for (const category of CATEGORY_OPTIONS) {
@@ -250,6 +297,7 @@ function fillForm(item) {
     modelInput.title = "";
   }
   categoryInput.value = normalizeCategory(item.category);
+  assetReferenceItemInput.value = item.assetReferenceItemCode ?? "";
   purchaseDateInput.value = item.purchaseDate;
   purchasePriceInput.value = item.purchasePrice;
   yearsOfUseInput.value = item.yearsOfUse;
@@ -257,6 +305,7 @@ function fillForm(item) {
   hideFromTimelineInput.checked = Boolean(item.hideFromTimeline);
   updateEndedUseStyle();
   renderAdditionalCosts(item.additionalCosts);
+  updateAssetReferenceDisplay();
 }
 
 populateCategorySelect();
@@ -287,6 +336,7 @@ additionalCostList.addEventListener("click", (event) => {
 
 form.addEventListener("input", updateCalculationResult);
 form.addEventListener("change", updateCalculationResult);
+assetReferenceItemInput?.addEventListener("change", updateAssetReferenceDisplay);
 purchasePriceInput.addEventListener("input", updateCalculationResult);
 yearsOfUseInput.addEventListener("input", updateCalculationResult);
 additionalCostList.addEventListener("input", updateCalculationResult);
@@ -306,6 +356,7 @@ form.addEventListener("submit", async (event) => {
     name: nameInput.value.trim(),
     model: modelInput.dataset.encodedModel || modelInput.value.trim(),
     category: categoryInput.value,
+    assetReferenceItemCode: assetReferenceItemInput?.value ?? "",
     purchaseDate: purchaseDateInput.value,
     purchasePrice: Number(purchasePriceInput.value),
     yearsOfUse: Number(yearsOfUseInput.value),
@@ -342,6 +393,13 @@ async function initializeForm(user) {
   } else {
     state.uid = user.uid;
   }
+
+  try {
+    state.assetReferenceData = await loadAssetReferenceData(state.uid);
+  } catch (_error) {
+    state.assetReferenceData = null;
+  }
+  populateAssetReferenceSelect();
 
   if (!state.editingId) {
     sessionStorageRemoveItem(EDITING_ITEM_ID_KEY);

--- a/js/services/asset-reference.js
+++ b/js/services/asset-reference.js
@@ -1,0 +1,194 @@
+import {
+  doc,
+  getDoc,
+  serverTimestamp,
+  setDoc,
+} from "https://www.gstatic.com/firebasejs/10.14.1/firebase-firestore.js";
+import { db } from "../platform/firebase.js";
+import { isLocalMode, storageGetItem, storageSetItem } from "../platform/local-db.js";
+
+const LOCAL_STORAGE_KEY = "monthlyApplianceBook.assetReferenceData";
+const REFERENCE_DOC_ID = "__assetReferenceData";
+const REFERENCE_SOURCE_TYPE = "assetReferenceData";
+const REFERENCE_SCHEMA_TYPE = "assetValuationReference";
+
+export const ASSET_REFERENCE_SOURCE = {
+  title: "耐久消費財の耐用年数，評価に用いる単価及び取得時期別残価率",
+  target: "二人以上の世帯",
+  url: "https://www.stat.go.jp/data/zensho/2014/pdf/assetest4.pdf",
+};
+
+const DEFAULT_KEYWORDS = {
+  "システムキッチン": ["システムキッチン"],
+  "太陽熱温水器": ["太陽熱温水器"],
+  "洗髪洗面化粧台": ["洗髪洗面化粧台", "洗面化粧台"],
+  "温水洗浄便座": ["温水洗浄便座", "ウォシュレット"],
+  "床暖房": ["床暖房"],
+  "太陽光発電システム": ["太陽光発電", "太陽光発電システム"],
+  "高効率給湯器": ["高効率給湯器", "給湯器"],
+  "家庭用コージェネレーションシステム": ["コージェネレーション", "エネファーム"],
+  "家庭用エネルギー管理システム": ["HEMS", "エネルギー管理システム"],
+  "電子レンジ（電子オーブンレンジを含む）": ["電子レンジ", "オーブンレンジ"],
+  "自動炊飯器（遠赤釜・ＩＨ型）": ["炊飯器", "自動炊飯器"],
+  "冷蔵庫": ["冷蔵庫"],
+  "電気掃除機": ["掃除機", "電気掃除機"],
+  "洗濯機": ["洗濯機"],
+  "ＩＨクッキングヒーター": ["IHクッキングヒーター", "ＩＨクッキングヒーター"],
+  "食器洗い機": ["食器洗い機", "食洗機"],
+  "ホームベーカリー": ["ホームベーカリー"],
+  "ルームエアコン": ["エアコン", "ルームエアコン"],
+  "空気清浄機": ["空気清浄機"],
+  "たんす(作り付けを除く)": ["たんす", "タンス"],
+  "食堂セット（食卓と椅子のセット）": ["食堂セット", "食卓", "ダイニングセット"],
+  "食器戸棚(作り付けを除く)": ["食器戸棚", "食器棚"],
+  "サイドボード･リビングボード": ["サイドボード", "リビングボード"],
+  "鏡台(ドレッサー)": ["鏡台", "ドレッサー"],
+  "ＬＥＤ照明器具(電球・蛍光灯を除く)": ["LED照明", "ＬＥＤ照明", "照明器具"],
+  "ベッド･ソファーベッド(作り付けを除く)": ["ベッド", "ソファーベッド"],
+  "電動アシスト自転車": ["電動アシスト自転車", "電動自転車"],
+  "カーナビゲーションシステム": ["カーナビ", "カーナビゲーション"],
+  "スマートフォン": ["スマホ", "スマートフォン"],
+  "携帯電話(PHSを含み，ｽﾏｰﾄﾌｫﾝを除く)": ["携帯電話", "ガラケー", "PHS"],
+  "テレビ": ["テレビ", "TV"],
+  "ビデオレコーダー(DVD・ﾌﾞﾙｰﾚｲを含む)": ["ビデオレコーダー", "DVD", "Blu-ray", "ブルーレイ"],
+  "ﾎｰﾑｼｱﾀｰ(ﾌﾟﾛｼﾞｪｸﾀｰ,ｽｸﾘｰﾝ,ｽﾋﾟｰｶｰのｾｯﾄ)": ["ホームシアター", "プロジェクター"],
+  "パソコン(デスクトップ型)": ["デスクトップ", "デスクトップPC"],
+  "パソコン(ノート型(ﾓﾊﾞｲﾙ・ﾈｯﾄﾌﾞｯｸを含む))": ["ノートPC", "ノートパソコン", "ラップトップ"],
+  "タブレット端末": ["タブレット", "タブレット端末"],
+  "カメラ": ["カメラ", "デジタルカメラ"],
+  "ビデオカメラ": ["ビデオカメラ"],
+  "ピアノ・電子ピアノ": ["ピアノ", "電子ピアノ"],
+  "書斎・学習用机(ﾗｲﾃｨﾝｸﾞﾃﾞｽｸを含む)": ["学習机", "書斎机", "デスク"],
+};
+
+function userReferenceDocRef(uid) {
+  return doc(db, "users", uid, "durableGoodsItems", REFERENCE_DOC_ID);
+}
+
+function parseNumber(value) {
+  const number = Number(String(value ?? "").replaceAll(",", ""));
+  return Number.isFinite(number) ? number : null;
+}
+
+function defaultKeywordsFor(label) {
+  const keywords = DEFAULT_KEYWORDS[label] ?? [];
+  return [...new Set([label, ...keywords].filter(Boolean))];
+}
+
+function normalizeReferenceItem(item) {
+  const usefulLifeYears = parseNumber(item?.usefulLifeYears);
+  const unitPrice = parseNumber(item?.unitPrice);
+  if (!item?.code || !item?.label || !usefulLifeYears || !unitPrice) return null;
+
+  const keywords = Array.isArray(item.keywords) ? item.keywords : defaultKeywordsFor(item.label);
+  return {
+    code: String(item.code).padStart(2, "0"),
+    label: String(item.label),
+    usefulLifeYears,
+    unitPrice,
+    keywords: [...new Set(keywords.map(String).filter(Boolean))],
+  };
+}
+
+function normalizeReferenceData(data) {
+  const items = Array.isArray(data?.items)
+    ? data.items.map(normalizeReferenceItem).filter(Boolean)
+    : [];
+
+  return {
+    source: {
+      ...ASSET_REFERENCE_SOURCE,
+      ...(data?.source && typeof data.source === "object" ? data.source : {}),
+    },
+    importedAt: data?.importedAt ?? null,
+    items,
+  };
+}
+
+function firestoreValueToReferenceData(data) {
+  return normalizeReferenceData(data);
+}
+
+function localStorageValueToReferenceData(value) {
+  if (!value) return null;
+  try {
+    return normalizeReferenceData(JSON.parse(value));
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function parseAssetReferenceText(text) {
+  const items = [];
+  const seenCodes = new Set();
+  const lines = String(text ?? "").split(/\r?\n/);
+  const itemPattern = /^(\d{2})\s+(.+?)\s+([0-9]+|-)\s+(?:[0-9.]+|-)\s+(?:[0-9.]+|-)\s+(?:[0-9.]+|-)\s+([0-9,]+|購入価格)\s+/;
+
+  for (const line of lines) {
+    const match = line.trim().match(itemPattern);
+    if (!match) continue;
+
+    const [, code, label, usefulLifeText, unitPriceText] = match;
+    if (seenCodes.has(code)) continue;
+    if (usefulLifeText === "-" || unitPriceText === "購入価格") continue;
+
+    const item = normalizeReferenceItem({
+      code,
+      label,
+      usefulLifeYears: usefulLifeText,
+      unitPrice: unitPriceText,
+      keywords: defaultKeywordsFor(label),
+    });
+    if (!item) continue;
+
+    seenCodes.add(code);
+    items.push(item);
+  }
+
+  if (items.length === 0) {
+    throw new Error("インポートできる行が見つかりませんでした。二人以上の世帯の表テキストを貼り付けてください。");
+  }
+
+  return {
+    source: ASSET_REFERENCE_SOURCE,
+    importedAt: new Date().toISOString(),
+    items,
+  };
+}
+
+export async function loadAssetReferenceData(uid) {
+  if (isLocalMode()) {
+    return localStorageValueToReferenceData(storageGetItem(LOCAL_STORAGE_KEY));
+  }
+
+  if (!uid) return null;
+  const snapshot = await getDoc(userReferenceDocRef(uid));
+  if (!snapshot.exists()) return null;
+  const data = snapshot.data();
+  if (data.sourceType !== REFERENCE_SOURCE_TYPE) return null;
+  return firestoreValueToReferenceData(data);
+}
+
+export async function saveAssetReferenceData(uid, data) {
+  const normalizedData = normalizeReferenceData({
+    ...data,
+    importedAt: data.importedAt ?? new Date().toISOString(),
+  });
+
+  if (isLocalMode()) {
+    storageSetItem(LOCAL_STORAGE_KEY, JSON.stringify(normalizedData));
+    return normalizedData;
+  }
+
+  if (!uid) {
+    throw new Error("参照データの保存にはログイン情報が必要です。");
+  }
+
+  await setDoc(userReferenceDocRef(uid), {
+    ...normalizedData,
+    sourceType: REFERENCE_SOURCE_TYPE,
+    schemaType: REFERENCE_SCHEMA_TYPE,
+    updatedAt: serverTimestamp(),
+  });
+  return normalizedData;
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -6,6 +6,11 @@ import {
   createFirebaseLocalBackupData,
   firebaseErrorMessage,
 } from "./common.js";
+import {
+  loadAssetReferenceData,
+  parseAssetReferenceText,
+  saveAssetReferenceData,
+} from "./services/asset-reference.js";
 import { isLocalMode } from "./platform/local-db.js";
 import { onAuthChanged, registerServiceWorker } from "./services/auth.js";
 
@@ -13,6 +18,10 @@ const includeUnderusedMonthlyCostInput = document.getElementById("include-underu
 const backButton = document.getElementById("back-button");
 const firebaseLocalBackupButton = document.getElementById("firebase-local-backup-button");
 const settingsStatus = document.getElementById("settings-status");
+const assetReferenceTextInput = document.getElementById("asset-reference-text");
+const assetReferenceImportButton = document.getElementById("asset-reference-import-button");
+const assetReferenceSummary = document.getElementById("asset-reference-summary");
+const assetReferenceStatus = document.getElementById("asset-reference-status");
 
 const state = {
   uid: null,
@@ -53,9 +62,47 @@ function setStatus(message) {
   if (settingsStatus) settingsStatus.textContent = message;
 }
 
+function setAssetReferenceStatus(message) {
+  if (assetReferenceStatus) assetReferenceStatus.textContent = message;
+}
+
+function formatImportedAt(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function updateAssetReferenceSummary(data) {
+  if (!assetReferenceSummary) return;
+  if (!data?.items?.length) {
+    assetReferenceSummary.textContent = "未インポート";
+    return;
+  }
+
+  const importedAt = formatImportedAt(data.importedAt);
+  assetReferenceSummary.textContent = importedAt
+    ? `${data.items.length}件インポート済み（${importedAt}）`
+    : `${data.items.length}件インポート済み`;
+}
+
 function syncFirebaseLocalBackupButton() {
   if (!firebaseLocalBackupButton) return;
   firebaseLocalBackupButton.disabled = isLocalMode() || !state.uid;
+}
+
+async function syncAssetReferenceSummary() {
+  try {
+    updateAssetReferenceSummary(await loadAssetReferenceData(state.uid));
+  } catch (error) {
+    setAssetReferenceStatus(firebaseErrorMessage(error, "参照データの読み込みに失敗しました。"));
+  }
 }
 
 firebaseLocalBackupButton?.addEventListener("click", async () => {
@@ -84,10 +131,27 @@ firebaseLocalBackupButton?.addEventListener("click", async () => {
   }
 });
 
+assetReferenceImportButton?.addEventListener("click", async () => {
+  setAssetReferenceStatus("");
+
+  try {
+    const text = assetReferenceTextInput?.value ?? "";
+    const referenceData = parseAssetReferenceText(text);
+    const savedData = await saveAssetReferenceData(state.uid, referenceData);
+    updateAssetReferenceSummary(savedData);
+    if (assetReferenceTextInput) assetReferenceTextInput.value = "";
+    setAssetReferenceStatus(`${savedData.items.length}件の参照データをインポートしました。`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "参照データのインポートに失敗しました。";
+    setAssetReferenceStatus(firebaseErrorMessage(error, message));
+  }
+});
+
 function showLocalModeBackupMessage() {
   state.uid = null;
   setStatus("ローカル保存用ファイル作成は、通常ログイン時のみ使用できます。");
   syncFirebaseLocalBackupButton();
+  syncAssetReferenceSummary();
 }
 
 if (isLocalMode()) {
@@ -102,6 +166,7 @@ if (isLocalMode()) {
     state.uid = user.uid;
     setStatus("");
     syncFirebaseLocalBackupButton();
+    syncAssetReferenceSummary();
   });
 }
 

--- a/js/storage/durable-items/firestore.js
+++ b/js/storage/durable-items/firestore.js
@@ -46,6 +46,7 @@ export async function saveItem(uid, item, options = {}) {
     name: item.name,
     model: item.model,
     category: item.category,
+    assetReferenceItemCode: item.assetReferenceItemCode,
     purchaseDate: item.purchaseDate,
     purchasePrice: item.purchasePrice,
     yearsOfUse: item.yearsOfUse,

--- a/js/storage/durable-items/service.js
+++ b/js/storage/durable-items/service.js
@@ -15,6 +15,8 @@ const LEGACY_CATEGORY_MAP = {
   pc: "information_device",
 };
 
+const ASSET_REFERENCE_SOURCE_TYPE = "assetReferenceData";
+
 function normalizeCategory(value) {
   const normalizedValue = String(value ?? "");
   const mappedValue = LEGACY_CATEGORY_MAP[normalizedValue] ?? normalizedValue;
@@ -27,6 +29,7 @@ function normalizeStoredItem(item) {
     name: item.name ?? "",
     model: item.model ?? "",
     category: normalizeCategory(item.category),
+    assetReferenceItemCode: String(item.assetReferenceItemCode ?? ""),
     sourceType: item.sourceType ?? "",
     purchaseDate: item.purchaseDate ?? "",
     purchasePrice: Number(item.purchasePrice ?? 0),
@@ -51,7 +54,9 @@ function sortStoredItems(items) {
 }
 
 export async function loadItems(uid) {
-  return sortStoredItems((await storage.getItems(uid)).map(normalizeStoredItem));
+  return sortStoredItems((await storage.getItems(uid))
+    .filter((item) => item?.sourceType !== ASSET_REFERENCE_SOURCE_TYPE)
+    .map(normalizeStoredItem));
 }
 
 export async function loadItem(uid, itemId) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v67";
+const CACHE_NAME = "durable-goods-pwa-v70";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",
@@ -18,6 +18,7 @@ const APP_SHELL = [
   "js/platform/firebase.js",
   "js/platform/local-db.js",
   "js/services/app-settings.js",
+  "js/services/asset-reference.js",
   "js/services/auth.js",
   "js/storage/durable-items/firestore.js",
   "js/storage/durable-items/index.js",

--- a/settings.html
+++ b/settings.html
@@ -44,6 +44,35 @@
         </div>
         <p id="settings-status" class="form-error"></p>
       </section>
+
+      <section class="panel settings-panel" aria-labelledby="asset-reference-settings-title">
+        <h2 id="asset-reference-settings-title">耐用年数・単価の参照データ</h2>
+        <div class="settings-action-card asset-reference-card">
+          <div>
+            <strong>PDF表テキストのインポート</strong>
+            <p>
+              総務省統計局のPDFを開き、「耐久消費財の耐用年数，評価に用いる単価及び取得時期別残価率（二人以上の世帯）」の表をコピーして貼り付けます。
+              PDFのダウンロード元:
+              <a href="https://www.stat.go.jp/data/zensho/2014/pdf/assetest4.pdf" target="_blank" rel="noopener">assetest4.pdf</a>
+            </p>
+            <p>
+              貼り付け後にインポートすると、商品名に一致した品目だけ、入力フォームの購入価格に参考単価、使用年数に耐用年数を薄字で表示します。
+              入力値は自動変更しません。
+            </p>
+          </div>
+          <textarea
+            id="asset-reference-text"
+            class="asset-reference-textarea"
+            rows="10"
+            placeholder="PDFからコピーした二人以上の世帯の表テキストを貼り付けてください"
+          ></textarea>
+          <div class="settings-action-row">
+            <button id="asset-reference-import-button" type="button" class="primary-button">インポート</button>
+            <span id="asset-reference-summary" class="settings-muted-text">未インポート</span>
+          </div>
+        </div>
+        <p id="asset-reference-status" class="form-error"></p>
+      </section>
     </main>
     <script type="module" src="js/settings.js"></script>
   </body>

--- a/style.css
+++ b/style.css
@@ -99,6 +99,21 @@ select {
   height: 44px;
 }
 
+.reference-input-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(150px, auto);
+  align-items: center;
+  gap: 10px;
+}
+
+.reference-hint {
+  min-height: 1.4em;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
 textarea {
   min-height: 104px;
   padding-top: 10px;
@@ -289,6 +304,29 @@ button {
 .settings-action-card .primary-button {
   min-width: 220px;
   padding: 0 18px;
+}
+
+.asset-reference-card {
+  align-items: stretch;
+  grid-template-columns: 1fr;
+}
+
+.asset-reference-textarea {
+  min-height: 220px;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.9rem;
+}
+
+.settings-action-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.settings-muted-text {
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
 .login-page {
@@ -656,6 +694,15 @@ button {
 @media (max-width: 520px) {
   .calculation-result {
     grid-template-columns: 1fr;
+  }
+
+  .reference-input-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+
+  .reference-hint {
+    white-space: normal;
   }
 
   .additional-cost-row {


### PR DESCRIPTION
## 概要
- 設定画面で耐用年数・単価の参照データを貼り付けインポートできるようにしました。
- 入力フォームに耐久消費財品目プルダウンを追加し、選択時に参考単価と耐用年数を表示します。
- 参照データは既存の durableGoodsItems 配下に特別なドキュメントとして保存し、通常商品一覧や集計から除外します。

## 確認
- node --check js/services/asset-reference.js
- node --check js/form.js
- node --check js/settings.js
- node --check js/storage/durable-items/service.js
- node --check js/storage/durable-items/firestore.js
- node --check js/common.js
- node --check service-worker.js