### PR TITLE
PWAのバージョンアップを手動反映に変更

### DIFF
--- a/js/form.js
+++ b/js/form.js
@@ -113,6 +113,8 @@ const state = {
   editingId: new URLSearchParams(window.location.search).get("id") || sessionStorageGetItem(EDITING_ITEM_ID_KEY),
   assetReferenceData: null,
   excludeFromSummary: false,
+  isDirty: false,
+  isBusy: false,
 };
 
 function updateAssetReferenceDisplay() {
@@ -319,6 +321,7 @@ toListButton.addEventListener("click", () => {
 
 
 addCostButton.addEventListener("click", () => {
+  state.isDirty = true;
   const row = createAdditionalCostRow({ createdAt: Date.now() });
   additionalCostList.prepend(row);
   row.querySelector(".additional-cost-amount")?.focus();
@@ -329,6 +332,7 @@ additionalCostList.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
   if (!target.classList.contains("additional-cost-delete")) return;
+  state.isDirty = true;
   target.closest(".additional-cost-row")?.remove();
   if (additionalCostList.children.length === 0) {
     additionalCostList.appendChild(createAdditionalCostRow({ createdAt: Date.now() }));
@@ -338,6 +342,12 @@ additionalCostList.addEventListener("click", (event) => {
 
 form.addEventListener("input", updateCalculationResult);
 form.addEventListener("change", updateCalculationResult);
+form.addEventListener("input", () => {
+  state.isDirty = true;
+});
+form.addEventListener("change", () => {
+  state.isDirty = true;
+});
 assetReferenceItemInput?.addEventListener("change", updateAssetReferenceDisplay);
 purchasePriceInput.addEventListener("input", updateCalculationResult);
 yearsOfUseInput.addEventListener("input", updateCalculationResult);
@@ -374,16 +384,19 @@ form.addEventListener("submit", async (event) => {
     return;
   }
   try {
+    state.isBusy = true;
     submitButton.disabled = true;
     await saveItem(state.uid, item);
     if (shouldShowHiddenTimelineNotice(item)) {
       await showHiddenTimelineNoticeDialog();
     }
     sessionStorageRemoveItem(EDITING_ITEM_ID_KEY);
+    state.isDirty = false;
     window.location.href = "list.html";
   } catch (error) {
     formError.textContent = firebaseErrorMessage(error, "保存に失敗しました。");
   } finally {
+    state.isBusy = false;
     submitButton.disabled = false;
   }
 });
@@ -410,6 +423,7 @@ async function initializeForm(user) {
     submitButton.textContent = "登録する";
     updateEndedUseStyle();
     renderAdditionalCosts([]);
+    state.isDirty = false;
     return;
   }
 
@@ -424,6 +438,7 @@ async function initializeForm(user) {
       return;
     }
     fillForm(item);
+    state.isDirty = false;
   } catch (error) {
     authError.textContent = firebaseErrorMessage(error, "データ取得に失敗しました。");
   }
@@ -435,4 +450,7 @@ if (isLocalMode()) {
   onAuthChanged(initializeForm);
 }
 
-registerServiceWorker();
+registerServiceWorker({
+  isBusy: () => state.isBusy,
+  isFormDirty: () => state.isDirty,
+});

--- a/js/list.js
+++ b/js/list.js
@@ -54,6 +54,7 @@ const state = {
   selectedCategories: new Set(CATEGORY_OPTIONS.map((category) => category.value)),
   selectedItemId: null,
   resizeTimer: null,
+  isBusy: false,
 };
 
 function sessionStorageSetItem(key, value) {
@@ -623,11 +624,13 @@ if (backupButton) {
       return;
     }
     try {
+      state.isBusy = true;
       backupButton.disabled = true;
       downloadBackupFile(await createLocalBackupData());
     } catch (error) {
       authError.textContent = error?.message || "バックアップの保存に失敗しました。";
     } finally {
+      state.isBusy = false;
       backupButton.disabled = false;
     }
   });
@@ -660,6 +663,7 @@ if (restoreButton) {
       return;
     }
     try {
+      state.isBusy = true;
       const file = await selectBackupFile();
       if (!file) return;
       const backup = parseLocalBackupText(await readFileAsText(file));
@@ -673,6 +677,7 @@ if (restoreButton) {
     } catch (error) {
       authError.textContent = error?.message || "バックアップの復元に失敗しました。";
     } finally {
+      state.isBusy = false;
       restoreButton.disabled = false;
     }
   });
@@ -785,4 +790,6 @@ if (isLocalMode()) {
   });
 }
 
-registerServiceWorker();
+registerServiceWorker({
+  isBusy: () => state.isBusy,
+});

--- a/js/services/auth.js
+++ b/js/services/auth.js
@@ -17,6 +17,12 @@ import {
 } from "../platform/local-db.js";
 
 const ALLOWED_USERS_COLLECTION = "allowedUsers";
+const VERSION_UPGRADE_MESSAGE = [
+  "入力中の内容が保存されていません。",
+  "バージョンアップすると入力内容が消える可能性があります。",
+  "先に保存してください。",
+].join("\n");
+const PROCESSING_MESSAGE = "処理中です。完了後にバージョンアップしてください。";
 
 function createAuthError(code, message) {
   const error = new Error(message);
@@ -32,10 +38,131 @@ function getUserEmail(user) {
   return email;
 }
 
-export function registerServiceWorker() {
+function pageHasBlockingProcess() {
+  return document.body?.dataset.versionUpgradeBusy === "true";
+}
+
+function createVersionUpgradeButton() {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "ghost-button version-upgrade-button";
+  button.textContent = "バージョンアップ";
+  button.hidden = true;
+  return button;
+}
+
+function mountVersionUpgradeButton(button) {
+  const dashboardActions = document.querySelector(".dashboard-title-actions");
+  if (dashboardActions) {
+    dashboardActions.prepend(button);
+    return;
+  }
+
+  const settingsHeader = document.querySelector(".settings-header");
+  if (settingsHeader) {
+    const backButton = settingsHeader.querySelector("#back-button");
+    if (backButton) {
+      backButton.before(button);
+    } else {
+      settingsHeader.append(button);
+    }
+    return;
+  }
+
+  const header = document.querySelector(".app-header");
+  const title = header?.querySelector("h1");
+  if (!header || !title) return;
+
+  const titleRow = document.createElement("div");
+  titleRow.className = "app-header-title-row";
+  title.before(titleRow);
+  titleRow.append(title, button);
+}
+
+function confirmVersionUpgradeWithDialog() {
+  if (typeof HTMLDialogElement === "undefined") {
+    return Promise.resolve(window.confirm(VERSION_UPGRADE_MESSAGE));
+  }
+
+  return new Promise((resolve) => {
+    const dialog = document.createElement("dialog");
+    dialog.className = "version-upgrade-dialog";
+
+    const card = document.createElement("article");
+    card.className = "version-upgrade-dialog-card";
+
+    const message = document.createElement("p");
+    message.textContent = VERSION_UPGRADE_MESSAGE;
+
+    const actions = document.createElement("div");
+    actions.className = "dialog-actions";
+
+    const cancelButton = document.createElement("button");
+    cancelButton.type = "button";
+    cancelButton.className = "ghost-button";
+    cancelButton.textContent = "キャンセル";
+
+    const upgradeButton = document.createElement("button");
+    upgradeButton.type = "button";
+    upgradeButton.className = "primary-button";
+    upgradeButton.textContent = "バージョンアップする";
+
+    actions.append(cancelButton, upgradeButton);
+    card.append(message, actions);
+    dialog.appendChild(card);
+
+    let shouldUpgrade = false;
+    cancelButton.addEventListener("click", () => dialog.close());
+    upgradeButton.addEventListener("click", () => {
+      shouldUpgrade = true;
+      dialog.close();
+    });
+    dialog.addEventListener("close", () => {
+      dialog.remove();
+      resolve(shouldUpgrade);
+    }, { once: true });
+
+    document.body.appendChild(dialog);
+    dialog.showModal();
+    cancelButton.focus();
+  });
+}
+
+export function registerServiceWorker(options = {}) {
   if (!("serviceWorker" in navigator)) return;
+  const isFormDirty = typeof options.isFormDirty === "function" ? options.isFormDirty : () => false;
+  const isBusy = typeof options.isBusy === "function" ? options.isBusy : () => false;
+  const upgradeButton = createVersionUpgradeButton();
+  let waitingWorker = null;
   let isReloadingForUpdate = false;
+  let shouldReloadOnControllerChange = false;
+
+  mountVersionUpgradeButton(upgradeButton);
+
+  function showUpgradeButton(worker) {
+    waitingWorker = worker;
+    upgradeButton.hidden = false;
+  }
+
+  async function requestVersionUpgrade() {
+    if (!waitingWorker) return;
+    if (isBusy() || pageHasBlockingProcess()) {
+      window.alert(PROCESSING_MESSAGE);
+      return;
+    }
+    if (isFormDirty()) {
+      const shouldUpgrade = await confirmVersionUpgradeWithDialog();
+      if (!shouldUpgrade) return;
+    }
+    upgradeButton.disabled = true;
+    shouldReloadOnControllerChange = true;
+    waitingWorker.postMessage({ type: "SKIP_WAITING" });
+  }
+
+  upgradeButton.addEventListener("click", requestVersionUpgrade);
+
   navigator.serviceWorker.addEventListener("controllerchange", () => {
+    if (!shouldReloadOnControllerChange) return;
     if (isReloadingForUpdate) return;
     isReloadingForUpdate = true;
     window.location.reload();
@@ -45,6 +172,19 @@ export function registerServiceWorker() {
     try {
       const registration = await navigator.serviceWorker.register(new URL("../../service-worker.js", import.meta.url), {
         scope: "../../",
+      });
+      if (registration.waiting) {
+        showUpgradeButton(registration.waiting);
+      }
+      registration.addEventListener("updatefound", () => {
+        const installingWorker = registration.installing;
+        if (!installingWorker) return;
+
+        installingWorker.addEventListener("statechange", () => {
+          if (installingWorker.state === "installed" && navigator.serviceWorker.controller) {
+            showUpgradeButton(installingWorker);
+          }
+        });
       });
       await registration.update();
     } catch (_error) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -35,6 +35,7 @@ const assetReferenceStatus = document.getElementById("asset-reference-status");
 
 const state = {
   uid: null,
+  isBusy: false,
   assetReferenceData: {
     items: [],
   },
@@ -189,12 +190,14 @@ firebaseLocalBackupButton?.addEventListener("click", async () => {
   }
 
   try {
+    state.isBusy = true;
     firebaseLocalBackupButton.disabled = true;
     const backup = await createFirebaseLocalBackupData(state.uid);
     downloadBackupFile(backup, localRestoreFileName());
   } catch (error) {
     setStatus(firebaseErrorMessage(error, "ローカル保存用ファイルの作成に失敗しました。"));
   } finally {
+    state.isBusy = false;
     syncFirebaseLocalBackupButton();
   }
 });
@@ -204,6 +207,7 @@ assetReferenceForm?.addEventListener("submit", async (event) => {
   setAssetReferenceStatus("");
 
   try {
+    state.isBusy = true;
     const editingId = assetReferenceIdInput instanceof HTMLInputElement ? assetReferenceIdInput.value : "";
     const item = createAssetReferenceItem({
       name: assetReferenceNameInput?.value ?? "",
@@ -233,6 +237,8 @@ assetReferenceForm?.addEventListener("submit", async (event) => {
   } catch (error) {
     const message = error instanceof Error ? error.message : "参照データの保存に失敗しました。";
     setAssetReferenceStatus(firebaseErrorMessage(error, message));
+  } finally {
+    state.isBusy = false;
   }
 });
 
@@ -292,6 +298,7 @@ assetReferenceList?.addEventListener("click", async (event) => {
 
   setAssetReferenceStatus("");
   try {
+    state.isBusy = true;
     button.disabled = true;
     const items = (state.assetReferenceData.items ?? []).filter((currentItem) => currentItem.id !== item.id);
     const resetCount = await resetDeletedAssetReferenceSelections(item.id);
@@ -310,6 +317,7 @@ assetReferenceList?.addEventListener("click", async (event) => {
   } catch (error) {
     setAssetReferenceStatus(firebaseErrorMessage(error, "参照項目の削除に失敗しました。"));
   } finally {
+    state.isBusy = false;
     button.disabled = false;
   }
 });
@@ -337,4 +345,6 @@ if (isLocalMode()) {
   });
 }
 
-registerServiceWorker();
+registerServiceWorker({
+  isBusy: () => state.isBusy,
+});

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -73,6 +73,8 @@ const state = {
   selectedItemId: null,
   editingId: new URLSearchParams(window.location.search).get("id"),
   resizeTimer: null,
+  isDirty: false,
+  isBusy: false,
 };
 function createId() {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -666,6 +668,7 @@ function resetForm() {
   elements.hideFromTimeline.checked = false;
   elements.submitButton.textContent = "登録する";
   elements.formError.textContent = "";
+  state.isDirty = false;
   updateCalculationResult();
 }
 
@@ -758,6 +761,12 @@ function showError(error, fallback) {
 if (elements.form) {
   elements.form.addEventListener("input", updateCalculationResult);
   elements.form.addEventListener("change", updateCalculationResult);
+  elements.form.addEventListener("input", () => {
+    state.isDirty = true;
+  });
+  elements.form.addEventListener("change", () => {
+    state.isDirty = true;
+  });
   elements.endOfUseDate.addEventListener("input", updateEndedUseStyle);
 
   elements.form.addEventListener("submit", async (event) => {
@@ -778,15 +787,18 @@ if (elements.form) {
     }
 
     try {
+      state.isBusy = true;
       elements.submitButton.disabled = true;
       await saveStorageItem(state.uid, item);
       if (shouldShowHiddenTimelineNotice(item)) {
         await showHiddenTimelineNoticeDialog();
       }
+      state.isDirty = false;
       window.location.href = "index.html";
     } catch (error) {
       elements.formError.textContent = firebaseErrorMessage(error, "パーツ情報の保存に失敗しました。");
     } finally {
+      state.isBusy = false;
       elements.submitButton.disabled = false;
     }
   });
@@ -942,6 +954,7 @@ async function initializePcManagement(user) {
       elements.yearsOfUse.value = elements.yearsOfUse.value || "5";
       updateEndedUseStyle();
       updateCalculationResult();
+      state.isDirty = false;
       return;
     }
 
@@ -952,6 +965,7 @@ async function initializePcManagement(user) {
       return;
     }
     fillForm(item);
+    state.isDirty = false;
   } catch (error) {
     showError(error, "パーツ情報の取得に失敗しました。");
   }
@@ -963,4 +977,7 @@ if (isLocalMode()) {
   onAuthChanged(initializePcManagement);
 }
 
-registerServiceWorker();
+registerServiceWorker({
+  isBusy: () => state.isBusy,
+  isFormDirty: () => Boolean(elements.form) && state.isDirty,
+});

--- a/pc-management/pwa.js
+++ b/pc-management/pwa.js
@@ -61,6 +61,10 @@ function setStatus(message) {
   if (authError) authError.textContent = message;
 }
 
+function setVersionUpgradeBusy(isBusy) {
+  document.body.dataset.versionUpgradeBusy = isBusy ? "true" : "false";
+}
+
 function downloadJson(data) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
@@ -144,11 +148,13 @@ backupButton?.addEventListener("click", async () => {
   }
 
   try {
+    setVersionUpgradeBusy(true);
     backupButton.disabled = true;
     downloadJson(await createBackupData());
   } catch (error) {
     setStatus(error?.message || "バックアップの保存に失敗しました。");
   } finally {
+    setVersionUpgradeBusy(false);
     backupButton.disabled = false;
   }
 });
@@ -162,6 +168,7 @@ restoreButton?.addEventListener("click", async () => {
   }
 
   try {
+    setVersionUpgradeBusy(true);
     const file = await selectBackupFile();
     if (!file) return;
     const records = parseBackupText(await readFileAsText(file));
@@ -174,6 +181,7 @@ restoreButton?.addEventListener("click", async () => {
   } catch (error) {
     setStatus(error?.message || "バックアップの復元に失敗しました。");
   } finally {
+    setVersionUpgradeBusy(false);
     restoreButton.disabled = false;
   }
 });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v93";
+const CACHE_NAME = "durable-goods-pwa-v94";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",
@@ -57,7 +57,6 @@ self.addEventListener("install", (event) => {
       return cache.addAll(APP_SHELL);
     })
   );
-  self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
@@ -101,4 +100,10 @@ self.addEventListener("fetch", (event) => {
         });
       })
   );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });

--- a/style.css
+++ b/style.css
@@ -33,6 +33,13 @@ body {
   font-size: 1.5rem;
 }
 
+.app-header-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .subtitle {
   margin: 8px 0 0;
   color: var(--muted);
@@ -235,6 +242,47 @@ button {
   color: var(--text);
   border: 1px solid var(--line);
   background: #fff;
+}
+
+.version-upgrade-button[hidden] {
+  display: none;
+}
+
+.version-upgrade-button {
+  flex: 0 0 auto;
+  min-width: 128px;
+  min-height: 40px;
+  margin-top: 0;
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+.version-upgrade-dialog {
+  width: min(420px, calc(100vw - 32px));
+  padding: 0;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+}
+
+.version-upgrade-dialog::backdrop {
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.version-upgrade-dialog-card {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.22);
+}
+
+.version-upgrade-dialog-card p {
+  margin: 0;
+  line-height: 1.7;
+  white-space: pre-line;
 }
 
 .settings-header {
@@ -836,7 +884,8 @@ button {
 .dashboard-title-row #logout-button,
 .dashboard-title-row #back-button,
 .dashboard-title-row #backup-button,
-.dashboard-title-row #restore-button {
+.dashboard-title-row #restore-button,
+.dashboard-title-row .version-upgrade-button {
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
@@ -855,10 +904,16 @@ button {
   background: rgba(36, 46, 57, 0.58);
 }
 
+.dashboard-title-row .version-upgrade-button {
+  width: auto;
+  min-width: 132px;
+}
+
 .dashboard-title-row #logout-button:hover,
 .dashboard-title-row #back-button:hover,
 .dashboard-title-row #backup-button:hover,
-.dashboard-title-row #restore-button:hover {
+.dashboard-title-row #restore-button:hover,
+.dashboard-title-row .version-upgrade-button:hover {
   background: rgba(54, 68, 82, 0.72);
 }
 
@@ -1710,13 +1765,19 @@ button {
   .dashboard-title-row #logout-button,
   .dashboard-title-row #back-button,
   .dashboard-title-row #backup-button,
-  .dashboard-title-row #restore-button {
+  .dashboard-title-row #restore-button,
+  .dashboard-title-row .version-upgrade-button {
     width: 96px;
     min-width: 96px;
     min-height: 38px;
     padding: 0 10px;
     border-radius: 4px;
     font-size: 0.72rem;
+  }
+
+  .dashboard-title-row .version-upgrade-button {
+    width: auto;
+    min-width: 116px;
   }
 
   .dashboard-body .subtitle {


### PR DESCRIPTION
PWAのバージョンアップを手動反映に変更

- Service Workerの即時切替をやめ、ユーザー操作で反映するよう変更
- 新しいService Worker検知時にヘッダーへ「バージョンアップ」ボタンを表示
- フォーム入力中は確認ダイアログを出して誤更新による入力消失を防止
- 保存中・復元中などの処理中はバージョンアップ実行を抑止
- PC管理画面にも同じ更新導線を適用
