### PR TITLE
使用年数未達品の月額計算設定を本体とPC管理に追加

### DIFF
--- a/hidden.html
+++ b/hidden.html
@@ -14,10 +14,12 @@
     <main class="app dashboard-app">
       <header class="app-header dashboard-header">
         <div class="dashboard-title">
-          <h1>非表示商品</h1>
-        </div>
-        <div class="dashboard-actions">
-          <button id="back-button" type="button" class="ghost-button" onclick="location.href='list.html'">戻る</button>
+          <div class="dashboard-title-row">
+            <h1>非表示商品</h1>
+            <div class="dashboard-title-actions">
+              <button id="back-button" type="button" class="ghost-button" onclick="location.href='list.html'">戻る</button>
+            </div>
+          </div>
         </div>
       </header>
 

--- a/js/list.js
+++ b/js/list.js
@@ -3,6 +3,7 @@ import {
   parseLocalBackupText,
   restoreLocalBackupData,
   calculateAdditionalCostTotal,
+  calculateActualMonthlyCost,
   calculateMonthlyCost,
   calculateMonthlyCostWithAdditionalCosts,
   formatCurrency,
@@ -13,6 +14,7 @@ import {
 } from "./common.js";
 import { isLocalMode } from "./platform/local-db.js";
 import { onAuthChanged, logout, registerServiceWorker } from "./services/auth.js";
+import { shouldExcludeUnderusedMonthlyCost } from "./services/app-settings.js";
 import { loadItems, removeItem, saveItem } from "./storage/durable-items/service.js";
 
 const EDITING_ITEM_ID_KEY = "monthlyApplianceBook.editingItemId";
@@ -228,6 +230,9 @@ function timelineMonthlyCost(item) {
 }
 
 function itemSummaryMonthlyCost(item) {
+  if (isUnderusedEndedItem(item) && !shouldExcludeUnderusedMonthlyCost()) {
+    return calculateActualMonthlyCost(item) ?? timelineMonthlyCost(item);
+  }
   return timelineMonthlyCost(item);
 }
 
@@ -240,7 +245,29 @@ function totalPurchaseCost(item) {
 }
 
 function isMonthlyCostExcluded(item) {
-  return Boolean(item.endOfUseDate) && itemPlannedEndMonth(item) < currentMonthIndex();
+  return isActualUseEnded(item) && itemPlannedEndMonth(item) <= currentMonthIndex();
+}
+
+function isActualUseEnded(item) {
+  return Boolean(item.endOfUseDate) && itemActualEndMonth(item) <= currentMonthIndex();
+}
+
+function isUnderusedEndedItem(item) {
+  return (
+    isActualUseEnded(item) &&
+    itemActualEndMonth(item) < itemPlannedEndMonth(item) &&
+    currentMonthIndex() < itemPlannedEndMonth(item)
+  );
+}
+
+function isMonthlyCostSummaryExcluded(item) {
+  if (isMonthlyCostExcluded(item)) {
+    return true;
+  }
+  if (isUnderusedEndedItem(item)) {
+    return shouldExcludeUnderusedMonthlyCost();
+  }
+  return false;
 }
 
 function isSummaryExcluded(item) {
@@ -249,7 +276,7 @@ function isSummaryExcluded(item) {
 
 function timelineLabelClass(item) {
   const classes = ["timeline-row-label"];
-  if (isMonthlyCostExcluded(item)) classes.push("monthly-cost-excluded");
+  if (isMonthlyCostSummaryExcluded(item)) classes.push("monthly-cost-excluded");
   if (isSummaryExcluded(item)) classes.push("summary-excluded");
   return classes.join(" ");
 }
@@ -272,7 +299,7 @@ function summarizeItems(items) {
   if (!summaryMonthlyCost || !summaryPurchaseTotal || !summaryItemCount) return;
 
   const summaryTargetItems = items.filter((item) => !isSummaryExcluded(item));
-  const monthlyCostItems = summaryTargetItems.filter((item) => !isMonthlyCostExcluded(item));
+  const monthlyCostItems = summaryTargetItems.filter((item) => !isMonthlyCostSummaryExcluded(item));
   const monthlyCostTotal = monthlyCostItems.reduce(
     (total, item) => total + displayedMonthlyCost(item),
     0

--- a/js/services/app-settings.js
+++ b/js/services/app-settings.js
@@ -1,14 +1,14 @@
 import { storageGetItem, storageSetItem } from "../platform/local-db.js";
 
-const INCLUDE_UNDERUSED_MONTHLY_COST_KEY = "monthlyApplianceBook.includeUnderusedMonthlyCost";
+const EXCLUDE_UNDERUSED_MONTHLY_COST_KEY = "monthlyApplianceBook.excludeUnderusedMonthlyCost";
 
-export function shouldIncludeUnderusedMonthlyCost() {
-  return storageGetItem(INCLUDE_UNDERUSED_MONTHLY_COST_KEY) === "true";
+export function shouldExcludeUnderusedMonthlyCost() {
+  return storageGetItem(EXCLUDE_UNDERUSED_MONTHLY_COST_KEY) === "true";
 }
 
-export function setIncludeUnderusedMonthlyCost(enabled) {
+export function setExcludeUnderusedMonthlyCost(enabled) {
   try {
-    storageSetItem(INCLUDE_UNDERUSED_MONTHLY_COST_KEY, enabled ? "true" : "false");
+    storageSetItem(EXCLUDE_UNDERUSED_MONTHLY_COST_KEY, enabled ? "true" : "false");
   } catch (_error) {
     // Settings are best-effort when browser storage is unavailable.
   }

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,6 +1,6 @@
 import {
-  setIncludeUnderusedMonthlyCost,
-  shouldIncludeUnderusedMonthlyCost,
+  setExcludeUnderusedMonthlyCost,
+  shouldExcludeUnderusedMonthlyCost,
 } from "./services/app-settings.js";
 import {
   createFirebaseLocalBackupData,
@@ -18,7 +18,7 @@ import {
   saveItem,
 } from "./storage/durable-items/service.js";
 
-const includeUnderusedMonthlyCostInput = document.getElementById("include-underused-monthly-cost");
+const excludeUnderusedMonthlyCostInput = document.getElementById("exclude-underused-monthly-cost");
 const backButton = document.getElementById("back-button");
 const firebaseLocalBackupButton = document.getElementById("firebase-local-backup-button");
 const settingsStatus = document.getElementById("settings-status");
@@ -41,10 +41,10 @@ const state = {
   },
 };
 
-if (includeUnderusedMonthlyCostInput instanceof HTMLInputElement) {
-  includeUnderusedMonthlyCostInput.checked = shouldIncludeUnderusedMonthlyCost();
-  includeUnderusedMonthlyCostInput.addEventListener("change", () => {
-    setIncludeUnderusedMonthlyCost(includeUnderusedMonthlyCostInput.checked);
+if (excludeUnderusedMonthlyCostInput instanceof HTMLInputElement) {
+  excludeUnderusedMonthlyCostInput.checked = shouldExcludeUnderusedMonthlyCost();
+  excludeUnderusedMonthlyCostInput.addEventListener("change", () => {
+    setExcludeUnderusedMonthlyCost(excludeUnderusedMonthlyCostInput.checked);
   });
 }
 

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -1,6 +1,10 @@
-import { firebaseErrorMessage } from "../js/common.js";
+import {
+  calculateUsageMonths,
+  firebaseErrorMessage,
+} from "../js/common.js";
 import { isLocalMode } from "../js/platform/local-db.js";
 import { onAuthChanged, registerServiceWorker } from "../js/services/auth.js";
+import { shouldExcludeUnderusedMonthlyCost } from "../js/services/app-settings.js";
 import {
   deleteItem as deletePcItem,
   getItems as getPcItems,
@@ -35,6 +39,7 @@ const elements = {
   createButton: document.getElementById("create-button"),
   categoryFilter: document.getElementById("category-filter"),
   hiddenButton: document.getElementById("hidden-button"),
+  settingsButton: document.getElementById("settings-button"),
   backButton: document.getElementById("back-button"),
   helpButton: document.getElementById("help-button"),
   helpDialog: document.getElementById("help-dialog"),
@@ -158,6 +163,14 @@ function calculateMonthlyCost(item) {
   return purchasePrice / (yearsOfUse * 12);
 }
 
+function calculateActualMonthlyCost(item) {
+  const usageMonths = calculateUsageMonths(item.purchaseDate, item.endOfUseDate);
+  if (!usageMonths) return null;
+  const purchasePrice = Number(item.purchasePrice ?? 0);
+  if (!Number.isFinite(purchasePrice)) return null;
+  return purchasePrice / usageMonths;
+}
+
 function shouldShowHiddenTimelineNotice(item) {
   return Boolean(item.hideFromTimeline);
 }
@@ -197,6 +210,9 @@ function showHiddenTimelineNoticeDialog() {
 }
 
 function summaryMonthlyCost(item) {
+  if (isUnderusedEndedItem(item) && !shouldExcludeUnderusedMonthlyCost()) {
+    return calculateActualMonthlyCost(item) ?? calculateMonthlyCost(item);
+  }
   return calculateMonthlyCost(item);
 }
 
@@ -205,7 +221,29 @@ function displayedMonthlyCost(item) {
 }
 
 function isMonthlyCostExcluded(item) {
-  return Boolean(item.endOfUseDate) && itemPlannedEndMonth(item) < currentMonthIndex();
+  return isActualUseEnded(item) && itemPlannedEndMonth(item) <= currentMonthIndex();
+}
+
+function isActualUseEnded(item) {
+  return Boolean(item.endOfUseDate) && itemActualEndMonth(item) <= currentMonthIndex();
+}
+
+function isUnderusedEndedItem(item) {
+  return (
+    isActualUseEnded(item) &&
+    itemActualEndMonth(item) < itemPlannedEndMonth(item) &&
+    currentMonthIndex() < itemPlannedEndMonth(item)
+  );
+}
+
+function isMonthlyCostSummaryExcluded(item) {
+  if (isMonthlyCostExcluded(item)) {
+    return true;
+  }
+  if (isUnderusedEndedItem(item)) {
+    return shouldExcludeUnderusedMonthlyCost();
+  }
+  return false;
 }
 
 function isSummaryExcluded(item) {
@@ -214,7 +252,7 @@ function isSummaryExcluded(item) {
 
 function timelineLabelClass(item) {
   const classes = ["timeline-row-label"];
-  if (isMonthlyCostExcluded(item)) classes.push("monthly-cost-excluded");
+  if (isMonthlyCostSummaryExcluded(item)) classes.push("monthly-cost-excluded");
   if (isSummaryExcluded(item)) classes.push("summary-excluded");
   return classes.join(" ");
 }
@@ -595,7 +633,7 @@ function renderSummary() {
   if (!elements.summaryCount || !elements.summaryTotal || !elements.summaryMonthly) return;
   const items = summaryItems();
   const summaryTargetItems = items.filter((item) => !isSummaryExcluded(item));
-  const monthlyCostItems = summaryTargetItems.filter((item) => !isMonthlyCostExcluded(item));
+  const monthlyCostItems = summaryTargetItems.filter((item) => !isMonthlyCostSummaryExcluded(item));
   const purchaseTotal = monthlyCostItems.reduce((total, item) => total + Number(item.purchasePrice || 0), 0);
   const monthlyCostTotal = monthlyCostItems.reduce((total, item) => total + displayedMonthlyCost(item), 0);
   elements.summaryCount.textContent = `${monthlyCostItems.length} 件`;
@@ -838,6 +876,12 @@ if (elements.categoryFilter) {
 if (elements.hiddenButton) {
   elements.hiddenButton.addEventListener("click", () => {
     window.location.href = "hidden.html";
+  });
+}
+
+if (elements.settingsButton) {
+  elements.settingsButton.addEventListener("click", () => {
+    window.location.href = "settings.html";
   });
 }
 

--- a/pc-management/hidden.html
+++ b/pc-management/hidden.html
@@ -15,10 +15,12 @@
     <main class="app dashboard-app">
       <header class="app-header dashboard-header">
         <div class="dashboard-title">
-          <h1>非表示パーツ</h1>
-        </div>
-        <div class="dashboard-actions">
-          <button id="back-button" type="button" class="ghost-button">戻る</button>
+          <div class="dashboard-title-row">
+            <h1>非表示パーツ</h1>
+            <div class="dashboard-title-actions">
+              <button id="back-button" type="button" class="ghost-button">戻る</button>
+            </div>
+          </div>
         </div>
       </header>
 

--- a/pc-management/index.html
+++ b/pc-management/index.html
@@ -52,6 +52,7 @@
       </section>
 
       <section class="pc-management-launch" aria-label="非表示パーツ">
+        <button id="settings-button" type="button" class="pc-management-button">設定</button>
         <a class="pc-management-button" href="hidden.html">非表示パーツ</a>
         <button id="help-button" type="button" class="pc-management-button help-button">ヘルプ</button>
       </section>

--- a/pc-management/settings.html
+++ b/pc-management/settings.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>設定 | パソコン管理</title>
+    <meta name="theme-color" content="#1f2933" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="icon" href="icons/icon-192.png" type="image/png" />
+    <link rel="apple-touch-icon" href="icons/icon-192.png" />
+    <link rel="stylesheet" href="../style.css" />
+    <link rel="stylesheet" href="pwa.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app-header settings-header">
+        <div>
+          <h1>設定</h1>
+          <p class="subtitle">パソコン管理の月額コスト計算方法を変更できます</p>
+        </div>
+        <button id="back-button" type="button" class="ghost-button">パソコン管理に戻る</button>
+      </header>
+
+      <section class="panel settings-panel" aria-labelledby="monthly-cost-settings-title">
+        <h2 id="monthly-cost-settings-title">月額コスト</h2>
+        <label class="settings-toggle" for="exclude-underused-monthly-cost">
+          <input id="exclude-underused-monthly-cost" type="checkbox" />
+          <span>
+            <strong>使用年数未達の月額コストを含めない</strong>
+            <small>チェックすると、予定より早く使用終了したパーツを月額合計から除外します。</small>
+          </span>
+        </label>
+      </section>
+    </main>
+    <script type="module" src="pwa.js"></script>
+    <script type="module" src="settings.js"></script>
+  </body>
+</html>

--- a/pc-management/settings.js
+++ b/pc-management/settings.js
@@ -1,0 +1,21 @@
+import {
+  setExcludeUnderusedMonthlyCost,
+  shouldExcludeUnderusedMonthlyCost,
+} from "../js/services/app-settings.js";
+import { registerServiceWorker } from "../js/services/auth.js";
+
+const excludeUnderusedMonthlyCostInput = document.getElementById("exclude-underused-monthly-cost");
+const backButton = document.getElementById("back-button");
+
+if (excludeUnderusedMonthlyCostInput instanceof HTMLInputElement) {
+  excludeUnderusedMonthlyCostInput.checked = shouldExcludeUnderusedMonthlyCost();
+  excludeUnderusedMonthlyCostInput.addEventListener("change", () => {
+    setExcludeUnderusedMonthlyCost(excludeUnderusedMonthlyCostInput.checked);
+  });
+}
+
+backButton?.addEventListener("click", () => {
+  window.location.href = "index.html";
+});
+
+registerServiceWorker();

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v94";
+const CACHE_NAME = "durable-goods-pwa-v98";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",
@@ -30,9 +30,11 @@ const APP_SHELL = [
   "pc-management/index.html",
   "pc-management/form.html",
   "pc-management/hidden.html",
+  "pc-management/settings.html",
   "pc-management/manifest.webmanifest",
   "pc-management/pwa.css",
   "pc-management/pwa.js",
+  "pc-management/settings.js",
   "pc-management/styles.css",
   "pc-management/app.js",
   "pc-management/icons/icon-192.png",

--- a/settings.html
+++ b/settings.html
@@ -22,11 +22,11 @@
 
       <section class="panel settings-panel" aria-labelledby="monthly-cost-settings-title">
         <h2 id="monthly-cost-settings-title">月額コスト</h2>
-        <label class="settings-toggle" for="include-underused-monthly-cost">
-          <input id="include-underused-monthly-cost" type="checkbox" />
+        <label class="settings-toggle" for="exclude-underused-monthly-cost">
+          <input id="exclude-underused-monthly-cost" type="checkbox" />
           <span>
-            <strong>使用年数未達家電の月額コストを含める</strong>
-            <small>予定より早く使用終了した家電を、実際の使用期間ベースで月額合計へ加算します。</small>
+            <strong>使用年数未達の月額コストを含めない</strong>
+            <small>チェックすると、予定より早く使用終了した家電を月額合計から除外します。</small>
           </span>
         </label>
       </section>


### PR DESCRIPTION
使用年数未達品の月額計算設定を本体とPC管理に追加

- 設定を「使用年数未達の月額コストを含めない」に変更
- 本体とPC管理で同じ設定キーを共有
- 使用年数未達で終了済みの商品・パーツを設定に応じて合計対象にする
- PC管理用の設定画面を追加
- Service Worker のキャッシュ名を更新
