### PR TITLE
PWA更新検知用にキャッシュ名を更新

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v94";
+const CACHE_NAME = "durable-goods-pwa-v95";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",


### PR DESCRIPTION
PWA更新検知用にキャッシュ名を更新

- Service Worker の CACHE_NAME を更新
- 既存の手動バージョンアップ導線は変更しない
- 通常アプリ、ローカル保存、PC管理PWAの更新検知対象にする
