### PR TITLE
PWA更新通知機能を削除しナビゲーション表示を整理

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -53,27 +53,6 @@ const LEGACY_CATEGORY_MAP = {
   pc: "information_device",
 };
 
-export function registerServiceWorker() {
-  if (!("serviceWorker" in navigator)) return;
-  let isReloadingForUpdate = false;
-  navigator.serviceWorker.addEventListener("controllerchange", () => {
-    if (isReloadingForUpdate) return;
-    isReloadingForUpdate = true;
-    window.location.reload();
-  });
-
-  window.addEventListener("load", async () => {
-    try {
-      const registration = await navigator.serviceWorker.register(new URL("../service-worker.js", import.meta.url), {
-        scope: "../",
-      });
-      await registration.update();
-    } catch (_error) {
-      // SW registration failure is non-fatal.
-    }
-  });
-}
-
 export function storageGetItem(key) {
   try {
     return localStorage.getItem(key);

--- a/js/form.js
+++ b/js/form.js
@@ -450,7 +450,4 @@ if (isLocalMode()) {
   onAuthChanged(initializeForm);
 }
 
-registerServiceWorker({
-  isBusy: () => state.isBusy,
-  isFormDirty: () => state.isDirty,
-});
+registerServiceWorker();

--- a/js/list.js
+++ b/js/list.js
@@ -817,6 +817,4 @@ if (isLocalMode()) {
   });
 }
 
-registerServiceWorker({
-  isBusy: () => state.isBusy,
-});
+registerServiceWorker();

--- a/js/services/auth.js
+++ b/js/services/auth.js
@@ -17,12 +17,6 @@ import {
 } from "../platform/local-db.js";
 
 const ALLOWED_USERS_COLLECTION = "allowedUsers";
-const VERSION_UPGRADE_MESSAGE = [
-  "入力中の内容が保存されていません。",
-  "バージョンアップすると入力内容が消える可能性があります。",
-  "先に保存してください。",
-].join("\n");
-const PROCESSING_MESSAGE = "処理中です。完了後にバージョンアップしてください。";
 
 function createAuthError(code, message) {
   const error = new Error(message);
@@ -38,153 +32,13 @@ function getUserEmail(user) {
   return email;
 }
 
-function pageHasBlockingProcess() {
-  return document.body?.dataset.versionUpgradeBusy === "true";
-}
-
-function createVersionUpgradeButton() {
-  const button = document.createElement("button");
-  button.type = "button";
-  button.className = "ghost-button version-upgrade-button";
-  button.textContent = "バージョンアップ";
-  button.hidden = true;
-  return button;
-}
-
-function mountVersionUpgradeButton(button) {
-  const dashboardActions = document.querySelector(".dashboard-title-actions");
-  if (dashboardActions) {
-    dashboardActions.prepend(button);
-    return;
-  }
-
-  const settingsHeader = document.querySelector(".settings-header");
-  if (settingsHeader) {
-    const backButton = settingsHeader.querySelector("#back-button");
-    if (backButton) {
-      backButton.before(button);
-    } else {
-      settingsHeader.append(button);
-    }
-    return;
-  }
-
-  const header = document.querySelector(".app-header");
-  const title = header?.querySelector("h1");
-  if (!header || !title) return;
-
-  const titleRow = document.createElement("div");
-  titleRow.className = "app-header-title-row";
-  title.before(titleRow);
-  titleRow.append(title, button);
-}
-
-function confirmVersionUpgradeWithDialog() {
-  if (typeof HTMLDialogElement === "undefined") {
-    return Promise.resolve(window.confirm(VERSION_UPGRADE_MESSAGE));
-  }
-
-  return new Promise((resolve) => {
-    const dialog = document.createElement("dialog");
-    dialog.className = "version-upgrade-dialog";
-
-    const card = document.createElement("article");
-    card.className = "version-upgrade-dialog-card";
-
-    const message = document.createElement("p");
-    message.textContent = VERSION_UPGRADE_MESSAGE;
-
-    const actions = document.createElement("div");
-    actions.className = "dialog-actions";
-
-    const cancelButton = document.createElement("button");
-    cancelButton.type = "button";
-    cancelButton.className = "ghost-button";
-    cancelButton.textContent = "キャンセル";
-
-    const upgradeButton = document.createElement("button");
-    upgradeButton.type = "button";
-    upgradeButton.className = "primary-button";
-    upgradeButton.textContent = "バージョンアップする";
-
-    actions.append(cancelButton, upgradeButton);
-    card.append(message, actions);
-    dialog.appendChild(card);
-
-    let shouldUpgrade = false;
-    cancelButton.addEventListener("click", () => dialog.close());
-    upgradeButton.addEventListener("click", () => {
-      shouldUpgrade = true;
-      dialog.close();
-    });
-    dialog.addEventListener("close", () => {
-      dialog.remove();
-      resolve(shouldUpgrade);
-    }, { once: true });
-
-    document.body.appendChild(dialog);
-    dialog.showModal();
-    cancelButton.focus();
-  });
-}
-
-export function registerServiceWorker(options = {}) {
+export function registerServiceWorker() {
   if (!("serviceWorker" in navigator)) return;
-  const isFormDirty = typeof options.isFormDirty === "function" ? options.isFormDirty : () => false;
-  const isBusy = typeof options.isBusy === "function" ? options.isBusy : () => false;
-  const upgradeButton = createVersionUpgradeButton();
-  let waitingWorker = null;
-  let isReloadingForUpdate = false;
-  let shouldReloadOnControllerChange = false;
-
-  mountVersionUpgradeButton(upgradeButton);
-
-  function showUpgradeButton(worker) {
-    waitingWorker = worker;
-    upgradeButton.hidden = false;
-  }
-
-  async function requestVersionUpgrade() {
-    if (!waitingWorker) return;
-    if (isBusy() || pageHasBlockingProcess()) {
-      window.alert(PROCESSING_MESSAGE);
-      return;
-    }
-    if (isFormDirty()) {
-      const shouldUpgrade = await confirmVersionUpgradeWithDialog();
-      if (!shouldUpgrade) return;
-    }
-    upgradeButton.disabled = true;
-    shouldReloadOnControllerChange = true;
-    waitingWorker.postMessage({ type: "SKIP_WAITING" });
-  }
-
-  upgradeButton.addEventListener("click", requestVersionUpgrade);
-
-  navigator.serviceWorker.addEventListener("controllerchange", () => {
-    if (!shouldReloadOnControllerChange) return;
-    if (isReloadingForUpdate) return;
-    isReloadingForUpdate = true;
-    window.location.reload();
-  });
 
   window.addEventListener("load", async () => {
     try {
       const registration = await navigator.serviceWorker.register(new URL("../../service-worker.js", import.meta.url), {
         scope: "../../",
-      });
-      if (registration.waiting) {
-        showUpgradeButton(registration.waiting);
-      }
-      registration.addEventListener("updatefound", () => {
-        const installingWorker = registration.installing;
-        if (!installingWorker) return;
-
-        installingWorker.addEventListener("statechange", () => {
-          if (installingWorker.state === "installed" && navigator.serviceWorker.controller) {
-            showUpgradeButton(installingWorker);
-          }
-        });
       });
       await registration.update();
     } catch (_error) {

--- a/js/settings.js
+++ b/js/settings.js
@@ -345,6 +345,4 @@ if (isLocalMode()) {
   });
 }
 
-registerServiceWorker({
-  isBusy: () => state.isBusy,
-});
+registerServiceWorker();

--- a/list.html
+++ b/list.html
@@ -52,8 +52,8 @@
 
       <section class="pc-management-launch" aria-label="パソコン管理">
         <button id="settings-button" type="button" class="pc-management-button">設定</button>
-        <a class="pc-management-button" href="hidden.html">非表示商品</a>
-        <a class="pc-management-button" href="pc-management/index.html">パソコン管理</a>
+        <a class="pc-management-button" href="hidden.html">非表示</a>
+        <a class="pc-management-button" href="pc-management/index.html">PC管理</a>
         <button id="help-button" type="button" class="pc-management-button help-button">ヘルプ</button>
       </section>
     </main>

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -1021,7 +1021,4 @@ if (isLocalMode()) {
   onAuthChanged(initializePcManagement);
 }
 
-registerServiceWorker({
-  isBusy: () => state.isBusy,
-  isFormDirty: () => Boolean(elements.form) && state.isDirty,
-});
+registerServiceWorker();

--- a/pc-management/index.html
+++ b/pc-management/index.html
@@ -53,7 +53,7 @@
 
       <section class="pc-management-launch" aria-label="非表示パーツ">
         <button id="settings-button" type="button" class="pc-management-button">設定</button>
-        <a class="pc-management-button" href="hidden.html">非表示パーツ</a>
+        <a class="pc-management-button" href="hidden.html">非表示</a>
         <button id="help-button" type="button" class="pc-management-button help-button">ヘルプ</button>
       </section>
     </main>

--- a/pc-management/pwa.js
+++ b/pc-management/pwa.js
@@ -61,10 +61,6 @@ function setStatus(message) {
   if (authError) authError.textContent = message;
 }
 
-function setVersionUpgradeBusy(isBusy) {
-  document.body.dataset.versionUpgradeBusy = isBusy ? "true" : "false";
-}
-
 function downloadJson(data) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
@@ -148,13 +144,11 @@ backupButton?.addEventListener("click", async () => {
   }
 
   try {
-    setVersionUpgradeBusy(true);
     backupButton.disabled = true;
     downloadJson(await createBackupData());
   } catch (error) {
     setStatus(error?.message || "バックアップの保存に失敗しました。");
   } finally {
-    setVersionUpgradeBusy(false);
     backupButton.disabled = false;
   }
 });
@@ -168,7 +162,6 @@ restoreButton?.addEventListener("click", async () => {
   }
 
   try {
-    setVersionUpgradeBusy(true);
     const file = await selectBackupFile();
     if (!file) return;
     const records = parseBackupText(await readFileAsText(file));
@@ -181,7 +174,6 @@ restoreButton?.addEventListener("click", async () => {
   } catch (error) {
     setStatus(error?.message || "バックアップの復元に失敗しました。");
   } finally {
-    setVersionUpgradeBusy(false);
     restoreButton.disabled = false;
   }
 });

--- a/pc-management/settings.html
+++ b/pc-management/settings.html
@@ -18,7 +18,7 @@
           <h1>設定</h1>
           <p class="subtitle">パソコン管理の月額コスト計算方法を変更できます</p>
         </div>
-        <button id="back-button" type="button" class="ghost-button">パソコン管理に戻る</button>
+        <button id="back-button" type="button" class="ghost-button">戻る</button>
       </header>
 
       <section class="panel settings-panel" aria-labelledby="monthly-cost-settings-title">

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v98";
+const CACHE_NAME = "durable-goods-pwa-v99";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",
@@ -102,10 +102,4 @@ self.addEventListener("fetch", (event) => {
         });
       })
   );
-});
-
-self.addEventListener("message", (event) => {
-  if (event.data?.type === "SKIP_WAITING") {
-    self.skipWaiting();
-  }
 });

--- a/settings.html
+++ b/settings.html
@@ -17,7 +17,7 @@
           <h1>設定</h1>
           <p class="subtitle">月額コストの計算方法を変更できます</p>
         </div>
-        <button id="back-button" type="button" class="ghost-button">一覧に戻る</button>
+        <button id="back-button" type="button" class="ghost-button">戻る</button>
       </header>
 
       <section class="panel settings-panel" aria-labelledby="monthly-cost-settings-title">

--- a/style.css
+++ b/style.css
@@ -244,47 +244,6 @@ button {
   background: #fff;
 }
 
-.version-upgrade-button[hidden] {
-  display: none;
-}
-
-.version-upgrade-button {
-  flex: 0 0 auto;
-  min-width: 128px;
-  min-height: 40px;
-  margin-top: 0;
-  padding: 0 12px;
-  white-space: nowrap;
-}
-
-.version-upgrade-dialog {
-  width: min(420px, calc(100vw - 32px));
-  padding: 0;
-  border: 0;
-  border-radius: 12px;
-  background: transparent;
-}
-
-.version-upgrade-dialog::backdrop {
-  background: rgba(15, 23, 42, 0.42);
-}
-
-.version-upgrade-dialog-card {
-  display: grid;
-  gap: 16px;
-  padding: 18px;
-  background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.22);
-}
-
-.version-upgrade-dialog-card p {
-  margin: 0;
-  line-height: 1.7;
-  white-space: pre-line;
-}
-
 .settings-header {
   display: flex;
   align-items: flex-start;
@@ -899,8 +858,7 @@ button {
 .dashboard-title-row #logout-button,
 .dashboard-title-row #back-button,
 .dashboard-title-row #backup-button,
-.dashboard-title-row #restore-button,
-.dashboard-title-row .version-upgrade-button {
+.dashboard-title-row #restore-button {
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
@@ -919,16 +877,10 @@ button {
   background: rgba(36, 46, 57, 0.58);
 }
 
-.dashboard-title-row .version-upgrade-button {
-  width: auto;
-  min-width: 132px;
-}
-
 .dashboard-title-row #logout-button:hover,
 .dashboard-title-row #back-button:hover,
 .dashboard-title-row #backup-button:hover,
-.dashboard-title-row #restore-button:hover,
-.dashboard-title-row .version-upgrade-button:hover {
+.dashboard-title-row #restore-button:hover {
   background: rgba(54, 68, 82, 0.72);
 }
 
@@ -1780,19 +1732,13 @@ button {
   .dashboard-title-row #logout-button,
   .dashboard-title-row #back-button,
   .dashboard-title-row #backup-button,
-  .dashboard-title-row #restore-button,
-  .dashboard-title-row .version-upgrade-button {
+  .dashboard-title-row #restore-button {
     width: 96px;
     min-width: 96px;
     min-height: 38px;
     padding: 0 10px;
     border-radius: 4px;
     font-size: 0.72rem;
-  }
-
-  .dashboard-title-row .version-upgrade-button {
-    width: auto;
-    min-width: 116px;
   }
 
   .dashboard-body .subtitle {
@@ -1992,11 +1938,14 @@ button {
   }
 
   .pc-management-launch {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
     gap: 6px;
     margin-top: 10px;
   }
 
   .pc-management-button {
+    width: 100%;
     min-height: 40px;
     min-width: 0;
     padding: 0 12px;


### PR DESCRIPTION
PWA更新通知機能を削除しボタン表示を整理

- Service Worker登録とキャッシュ機能は維持
- バージョンアップ通知UIとskipWaiting処理を削除
- 未使用の更新通知CSSと補助コードを削除
- スマホ表示の管理ボタンを等幅化
- ナビゲーション文言を短く整理
