### PR TITLE
パソコンのスペックの一覧表示

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "type": "chrome",
       "request": "launch",
       "name": "ローカルアプリを起動",
-      "url": "http://127.0.0.1:5501/list.html",
+      "url": "http://127.0.0.1:5501/login.html",
       "webRoot": "${workspaceFolder}",
       "preLaunchTask": "local-server-5501"
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,25 +4,15 @@
     {
       "label": "local-server-5501",
       "type": "process",
-      "command": "python",
-      "args": ["-u", "-m", "http.server", "5501", "--bind", "127.0.0.1"],
-      "options": {
-        "cwd": "${workspaceFolder}"
-      },
-      "isBackground": true,
-      "problemMatcher": {
-        "owner": "local-server",
-        "pattern": {
-          "regexp": "^(LOCAL_SERVER_NEVER_MATCHES)$",
-          "file": 1,
-          "message": 1
-        },
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": ".*",
-          "endsPattern": "Serving HTTP on .* port 5501"
-        }
-      },
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "$port = 5501; $address = '127.0.0.1'; $url = 'http://' + $address + ':' + $port + '/'; $outLog = Join-Path $env:TEMP 'taikyuusyouhizai-kanri-local-server-5501.out.log'; $errLog = Join-Path $env:TEMP 'taikyuusyouhizai-kanri-local-server-5501.err.log'; $listener = Get-NetTCPConnection -LocalAddress $address -LocalPort $port -State Listen -ErrorAction SilentlyContinue; if (-not $listener) { Start-Process -FilePath python -ArgumentList '-u -m http.server 5501 --bind 127.0.0.1' -WorkingDirectory '${workspaceFolder}' -WindowStyle Hidden -RedirectStandardOutput $outLog -RedirectStandardError $errLog }; for ($i = 0; $i -lt 20; $i++) { $listener = Get-NetTCPConnection -LocalAddress $address -LocalPort $port -State Listen -ErrorAction SilentlyContinue; if ($listener) { Write-Host \"Local server ready: $url\"; exit 0 }; Start-Sleep -Milliseconds 250 }; Write-Error \"Local server did not start: $url\"; exit 1"
+      ],
+      "problemMatcher": [],
       "presentation": {
         "reveal": "silent",
         "panel": "dedicated",

--- a/list.html
+++ b/list.html
@@ -22,7 +22,6 @@
               <button id="logout-button" type="button" class="ghost-button">ログアウト</button>
             </div>
           </div>
-          <p class="subtitle">耐久消費財の月割りコスト管理</p>
         </div>
         <section class="summary-panel" aria-label="集計">
           <div class="summary-item summary-item-primary">

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -25,6 +25,8 @@ const MOBILE_LABEL_WIDTH = 72;
 const TIMELINE_MODE = document.body.dataset.timelineMode || "visible";
 const SUMMARY_TOGGLE_LONG_PRESS_MS = 600;
 const SUMMARY_TOGGLE_MOVE_CANCEL_PX = 10;
+const PC_FILTER_LONG_PRESS_MS = 600;
+const PC_FILTER_MOVE_CANCEL_PX = 10;
 
 const pcNameLabels = {
   main: "メインPC",
@@ -71,6 +73,9 @@ const elements = {
   dialogEditButton: document.getElementById("dialog-edit-button"),
   dialogDeleteButton: document.getElementById("dialog-delete-button"),
   dialogCloseButton: document.getElementById("dialog-close-button"),
+  specListTitle: document.getElementById("spec-list-title"),
+  specListContent: document.getElementById("spec-list-content"),
+  specSaveButton: document.getElementById("spec-save-button"),
 };
 
 const state = {
@@ -83,6 +88,8 @@ const state = {
   isDirty: false,
   isBusy: false,
   summaryToggleLongPress: null,
+  pcFilterLongPress: null,
+  ignoreNextCategoryClick: false,
 };
 function createId() {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -157,6 +164,22 @@ function formatYearMonthFromIndex(monthIndex) {
 
 function formatMonthlyCost(value) {
   return `${formatCurrency(value)} /月`;
+}
+
+function formatTextValue(value) {
+  return String(value ?? "").trim() || "未入力";
+}
+
+function fileTimestamp() {
+  const now = new Date();
+  const parts = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+  ];
+  return `${parts[0]}${parts[1]}${parts[2]}-${parts[3]}${parts[4]}`;
 }
 
 function calculateMonthlyCost(item) {
@@ -665,6 +688,195 @@ function render() {
   renderCategoryFilter();
   renderSummary();
   renderTimeline();
+  renderSpecList();
+}
+
+function specListPcName() {
+  return normalizePcName(new URLSearchParams(window.location.search).get("pcName"));
+}
+
+function specListItems() {
+  const pcName = specListPcName();
+  return sortItems(state.items).filter((item) =>
+    item.pcName === pcName &&
+    !isSummaryExcluded(item) &&
+    (!item.hideFromTimeline || !item.endOfUseDate)
+  );
+}
+
+function specListRows() {
+  return specListItems().map((item) => ({
+    partName: formatTextValue(item.partName),
+    modelNumber: formatTextValue(item.modelNumber),
+    specDetail: formatTextValue(item.specDetail),
+    purchaseDate: formatTextValue(item.purchaseDate),
+    purchasePrice: formatCurrency(item.purchasePrice),
+    yearsOfUse: `${Number(item.yearsOfUse) || 0} 年`,
+    endOfUseDate: formatTextValue(item.endOfUseDate),
+    monthlyCost: formatMonthlyCost(calculateMonthlyCost(item)),
+  }));
+}
+
+function specListPurchaseTotal() {
+  return specListItems().reduce((total, item) => total + Number(item.purchasePrice || 0), 0);
+}
+
+function openSpecListValueDialog(value) {
+  const dialog = document.createElement("dialog");
+  dialog.className = "item-name-dialog spec-value-dialog";
+
+  const card = document.createElement("article");
+  card.className = "item-name-dialog-card";
+
+  const text = document.createElement("p");
+  text.className = "dialog-item-meta spec-value-dialog-text";
+  text.textContent = value;
+
+  const actions = document.createElement("div");
+  actions.className = "dialog-actions";
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "ghost-button";
+  closeButton.textContent = "閉じる";
+
+  closeButton.addEventListener("click", () => {
+    dialog.close();
+  });
+  dialog.addEventListener("click", (event) => {
+    if (event.target === dialog) dialog.close();
+  });
+  dialog.addEventListener("close", () => dialog.remove(), { once: true });
+
+  actions.appendChild(closeButton);
+  card.append(text, actions);
+  dialog.appendChild(card);
+  document.body.appendChild(dialog);
+  dialog.showModal();
+  closeButton.focus();
+}
+
+function renderSpecList() {
+  if (!elements.specListContent) return;
+
+  const pcName = specListPcName();
+  const pcLabel = pcNameLabels[pcName] || pcNameLabels.main;
+  const rows = specListRows();
+  if (elements.specListTitle) {
+    elements.specListTitle.textContent = `${pcLabel} スペック一覧`;
+  }
+
+  elements.specListContent.innerHTML = "";
+  if (rows.length === 0) {
+    const empty = createElement("div", "timeline-empty");
+    empty.innerHTML = `
+      <strong>表示できるパーツがありません</strong>
+      <span>月額合計から除外していないパーツが表示されます。</span>
+    `;
+    elements.specListContent.appendChild(empty);
+    return;
+  }
+
+  const scroll = createElement("div", "spec-list-scroll");
+  scroll.tabIndex = 0;
+  scroll.setAttribute("aria-label", "スペック一覧。横にスクロールできます。");
+
+  const table = createElement("table", "spec-list-table");
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th>商品名</th>
+        <th>型番</th>
+        <th>スペック</th>
+        <th>購入日</th>
+        <th>購入価格</th>
+        <th>使用年数</th>
+        <th>使用終了日</th>
+        <th>月額コスト</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  `;
+
+  const tbody = table.querySelector("tbody");
+  for (const row of rows) {
+    const tr = document.createElement("tr");
+    for (const key of [
+      "partName",
+      "modelNumber",
+      "specDetail",
+      "purchaseDate",
+      "purchasePrice",
+      "yearsOfUse",
+      "endOfUseDate",
+      "monthlyCost",
+    ]) {
+      const td = document.createElement("td");
+      if (key === "partName" || key === "specDetail") {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "spec-list-value-button";
+        button.textContent = row[key];
+        button.title = row[key];
+        button.addEventListener("click", () => {
+          openSpecListValueDialog(row[key]);
+        });
+        td.appendChild(button);
+      } else {
+        td.textContent = row[key];
+      }
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+
+  const total = createElement("p", "spec-list-total");
+  total.innerHTML = `<span>${pcLabel}の総購入金額</span><strong>${formatCurrency(specListPurchaseTotal())}</strong>`;
+
+  scroll.appendChild(table);
+  elements.specListContent.append(scroll, total);
+}
+
+function csvValue(value) {
+  return `"${String(value ?? "").replaceAll('"', '""')}"`;
+}
+
+function specListCsv() {
+  const pcLabel = pcNameLabels[specListPcName()] || pcNameLabels.main;
+  const lines = [
+    [csvValue(`${pcLabel} スペック一覧`)],
+    [],
+    ["商品名", "型番", "スペック", "購入日", "購入価格", "使用年数", "使用終了日", "月額コスト"].map(csvValue),
+  ];
+
+  for (const row of specListRows()) {
+    lines.push([
+      row.partName,
+      row.modelNumber,
+      row.specDetail,
+      row.purchaseDate,
+      row.purchasePrice,
+      row.yearsOfUse,
+      row.endOfUseDate,
+      row.monthlyCost,
+    ].map(csvValue));
+  }
+
+  lines.push([], ["総購入金額", formatCurrency(specListPurchaseTotal())].map(csvValue));
+  return lines.map((line) => line.join(",")).join("\r\n");
+}
+
+function saveSpecListCsv() {
+  const pcName = specListPcName();
+  const blob = new Blob([`\uFEFF${specListCsv()}`], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `pc-spec-list-${pcName}-${fileTimestamp()}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
 }
 
 function validatePcItem(item) {
@@ -867,6 +1079,28 @@ function cancelMovedSummaryToggleLongPress(event) {
   }
 }
 
+function clearPcFilterLongPress() {
+  if (!state.pcFilterLongPress) return;
+  window.clearTimeout(state.pcFilterLongPress.timer);
+  state.pcFilterLongPress = null;
+}
+
+function cancelPcFilterLongPress(event) {
+  if (!state.pcFilterLongPress || state.pcFilterLongPress.pointerId !== event.pointerId) return;
+  clearPcFilterLongPress();
+}
+
+function cancelMovedPcFilterLongPress(event) {
+  const longPress = state.pcFilterLongPress;
+  if (!longPress || longPress.pointerId !== event.pointerId) return;
+
+  const movedX = Math.abs(event.clientX - longPress.startX);
+  const movedY = Math.abs(event.clientY - longPress.startY);
+  if (movedX > PC_FILTER_MOVE_CANCEL_PX || movedY > PC_FILTER_MOVE_CANCEL_PX) {
+    clearPcFilterLongPress();
+  }
+}
+
 function showError(error, fallback) {
   if (elements.authError) {
     elements.authError.textContent = firebaseErrorMessage(error, fallback);
@@ -931,6 +1165,12 @@ if (elements.createButton) {
 
 if (elements.categoryFilter) {
   elements.categoryFilter.addEventListener("click", (event) => {
+    if (state.ignoreNextCategoryClick) {
+      state.ignoreNextCategoryClick = false;
+      event.preventDefault();
+      return;
+    }
+
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
 
@@ -948,6 +1188,35 @@ if (elements.categoryFilter) {
 
     render();
   });
+
+  elements.categoryFilter.addEventListener("pointerdown", (event) => {
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+
+    const button = target.closest(".category-filter-button");
+    if (!(button instanceof HTMLButtonElement)) return;
+
+    const pcName = button.dataset.pcName;
+    if (!pcName) return;
+
+    clearPcFilterLongPress();
+    state.pcFilterLongPress = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      timer: window.setTimeout(() => {
+        state.pcFilterLongPress = null;
+        state.ignoreNextCategoryClick = true;
+        window.location.href = `specs.html?pcName=${encodeURIComponent(pcName)}`;
+      }, PC_FILTER_LONG_PRESS_MS),
+    };
+  });
+
+  elements.categoryFilter.addEventListener("pointerup", cancelPcFilterLongPress);
+  elements.categoryFilter.addEventListener("pointercancel", cancelPcFilterLongPress);
+  elements.categoryFilter.addEventListener("pointerleave", cancelPcFilterLongPress);
+  elements.categoryFilter.addEventListener("pointermove", cancelMovedPcFilterLongPress);
 }
 
 if (elements.hiddenButton) {
@@ -962,7 +1231,7 @@ if (elements.settingsButton) {
   });
 }
 
-if (elements.backButton) {
+if (elements.backButton && !elements.specListContent) {
   elements.backButton.addEventListener("click", () => {
     window.location.href = TIMELINE_MODE === "hidden" ? "index.html" : "../list.html";
   });
@@ -1033,6 +1302,16 @@ if (elements.dialogCloseButton) {
   elements.dialogCloseButton.addEventListener("click", () => {
     elements.itemDialog.close();
   });
+}
+
+if (elements.backButton && elements.specListContent) {
+  elements.backButton.addEventListener("click", () => {
+    window.location.href = "index.html";
+  });
+}
+
+if (elements.specSaveButton) {
+  elements.specSaveButton.addEventListener("click", saveSpecListCsv);
 }
 
 if (elements.itemDialog) {

--- a/pc-management/index.html
+++ b/pc-management/index.html
@@ -23,7 +23,6 @@
               <button id="back-button" type="button" class="ghost-button">戻る</button>
             </div>
           </div>
-          <p class="subtitle">パーツの月割りコスト管理</p>
         </div>
         <section class="summary-panel" aria-label="集計">
           <div class="summary-item summary-item-primary">
@@ -75,6 +74,8 @@
           </div>
           <p>分類名を長押しすると、その商品を集計に含める／含めないを切り替えられます。集計に含めない商品は分類名が青紫で表示されます。</p>
           <p>赤色は、使用終了日を入力済みで、現在の月額計算から除外されているパーツを示します。</p>
+          <p>分類（パソコン）ボタンを長押しすると、選択中のパソコンのスペック一覧を表示できます。商品名・型番・スペック・購入日・購入価格・使用年数・使用終了日・月額コストを横スクロールで確認でき、一覧の下に総購入金額が表示されます。CSVファイルで保存することができます。</p>
+          <p>省略しているものはタップするとみることができます。</p>
         </section>
 
         <section class="help-section" aria-labelledby="help-concept-title">

--- a/pc-management/specs.html
+++ b/pc-management/specs.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>スペック一覧 | パソコン管理</title>
+    <meta name="theme-color" content="#1f2933" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="icon" href="icons/icon-192.png" type="image/png" />
+    <link rel="apple-touch-icon" href="icons/icon-192.png" />
+    <link rel="stylesheet" href="../style.css" />
+    <link rel="stylesheet" href="pwa.css" />
+  </head>
+  <body class="dashboard-body spec-list-body">
+    <main class="app dashboard-app">
+      <header class="app-header dashboard-header spec-list-header">
+        <div class="dashboard-title">
+          <div class="dashboard-title-row">
+            <h1 id="spec-list-title">スペック一覧</h1>
+            <div class="dashboard-title-actions pc-management-title-actions">
+              <button id="back-button" type="button" class="ghost-button">戻る</button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section class="panel spec-list-panel" aria-labelledby="spec-list-title">
+        <p id="auth-error" class="form-error"></p>
+        <div id="spec-list-content"></div>
+      </section>
+
+      <section class="spec-list-actions" aria-label="スペック一覧の操作">
+        <button id="spec-save-button" type="button" class="pc-management-button">保存</button>
+      </section>
+    </main>
+    <script type="module" src="pwa.js"></script>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -28,6 +28,7 @@ const APP_SHELL = [
   "js/storage/pc-items/index.js",
   "js/storage/pc-items/local.js",
   "pc-management/index.html",
+  "pc-management/specs.html",
   "pc-management/form.html",
   "pc-management/hidden.html",
   "pc-management/settings.html",

--- a/style.css
+++ b/style.css
@@ -1549,6 +1549,132 @@ button {
   background: rgba(63, 78, 92, 0.86);
 }
 
+.spec-list-header {
+  align-items: flex-start;
+}
+
+.spec-list-panel {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+}
+
+.spec-list-scroll {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.spec-list-scroll:focus {
+  outline: 2px solid rgba(59, 163, 255, 0.58);
+  outline-offset: 2px;
+}
+
+.spec-list-table {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  color: #f8fafc;
+}
+
+.spec-list-table th,
+.spec-list-table td {
+  min-width: 140px;
+  max-width: 280px;
+  padding: 12px 14px;
+  border-right: 1px solid rgba(226, 232, 240, 0.16);
+  border-bottom: 1px solid rgba(226, 232, 240, 0.16);
+  text-align: left;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.spec-list-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  color: #e5edf5;
+  background: rgba(25, 35, 45, 0.98);
+  font-size: 0.86rem;
+}
+
+.spec-list-table td {
+  background: rgba(46, 59, 70, 0.74);
+  font-size: 0.94rem;
+}
+
+.spec-list-table tr:nth-child(even) td {
+  background: rgba(37, 50, 61, 0.8);
+}
+
+.spec-list-table th:first-child,
+.spec-list-table td:first-child {
+  min-width: 180px;
+}
+
+.spec-list-table th:nth-child(3),
+.spec-list-table td:nth-child(3) {
+  min-width: 260px;
+}
+
+.spec-list-value-button {
+  display: block;
+  width: 100%;
+  min-height: 0;
+  padding: 0;
+  overflow: hidden;
+  color: #f8fafc;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  font: inherit;
+  font-weight: 700;
+  text-align: left;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.spec-list-value-button:hover,
+.spec-list-value-button:focus-visible {
+  color: #ffffff;
+  outline: 2px solid rgba(59, 163, 255, 0.58);
+  outline-offset: 2px;
+}
+
+.spec-value-dialog {
+  width: min(560px, calc(100% - 32px));
+}
+
+.spec-value-dialog-text {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.spec-list-total {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 10px;
+  margin: 0;
+  color: #d4dee8;
+  font-weight: 800;
+}
+
+.spec-list-total strong {
+  color: #f8fafc;
+  font-size: 1.35rem;
+}
+
+.spec-list-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 18px;
+  padding-bottom: 12px;
+}
+
 .help-button {
   min-width: 120px;
 }


### PR DESCRIPTION
PC管理のスペック一覧機能追加

pc-management/specs.html を新規追加
メインPC / サブPC別のスペック一覧画面
戻る ボタン
保存 ボタン
新規登録ボタン右側のメインPC / サブPCボタンを長押しすると、対象PCのスペック一覧を開く
ワンタップのメインPC / サブPC表示切替は維持
一覧表示項目:
商品名
型番
スペック
購入日
購入価格
使用年数
使用終了日
月額コスト
月額合計から除外済み、つまり青紫のパーツは一覧に出さない
非表示でも使用終了日が未入力のパーツは一覧に出す
一覧の下に総購入金額を表示
商品名・スペックは省略表示し、タップで全文だけのダイアログを表示
保存はCSVファイル出力
UTF-8 BOM付き
カンマ、改行、ダブルクォート対応
ヘルプ更新

パソコン管理ヘルプにスペック一覧の説明を追加
省略表示はタップで見られる説明を追加
ただし、ヘルプ整理の作業はまだ未実施です。今は文章が追加された状態です。
見た目調整

スペック一覧画面を既存のメイン画面と同じ暗めの配色に調整
横スクロール表を追加
一覧画面の戻るボタンをメイン画面と同じ見た目に修正
サブタイトルを削除
パーツの月割りコスト管理
選択中のパソコンの部品一覧
耐久消費財の月割りコスト管理
PWA対応

service-worker.js に pc-management/specs.html を追加
PWAキャッシュ対象に含めるため
VS Codeローカル起動設定の修正

.vscode/launch.json
起動URLを list.html から login.html に変更
.vscode/tasks.json
ローカルサーバー起動をPowerShell経由に変更
すでに 127.0.0.1:5501 が起動中なら再起動しない
未起動ならPythonサーバーを非表示で起動