### PR TITLE
Fix mobile timeline handle placement

### DIFF
--- a/js/list.js
+++ b/js/list.js
@@ -426,8 +426,14 @@ function renderCurrentLine(grid, minYear, maxYear) {
   if (currentPosition !== null) {
     const currentLine = createElement("div", "timeline-current-line");
     currentLine.style.left = `${currentPosition}px`;
-    currentLine.innerHTML = '<button type="button" class="timeline-current-handle" data-action="drag-current-line" aria-label="現在ラインを動かす">✋</button>';
     grid.appendChild(currentLine);
+
+    const currentHandle = createElement("button", "timeline-current-handle", "✋");
+    currentHandle.type = "button";
+    currentHandle.dataset.action = "drag-current-line";
+    currentHandle.setAttribute("aria-label", "現在ラインを動かす");
+    currentHandle.style.left = `${currentPosition}px`;
+    grid.appendChild(currentHandle);
   }
 
   if (currentLabelPosition !== null) {
@@ -665,7 +671,10 @@ function timelineMonthFromClientX(clientX, scroll, minYear, maxYear) {
 function applyTimelineMarkerDragPosition(drag) {
   state.timelineMarkerMonth = timelineMonthFromClientX(drag.clientX, drag.scroll, drag.minYear, drag.maxYear);
   const position = currentLinePosition(drag.minYear, drag.maxYear);
-  if (position !== null) drag.line.style.left = `${position}px`;
+  if (position !== null) {
+    drag.line.style.left = `${position}px`;
+    drag.handle.style.left = `${position}px`;
+  }
   summarizeItems(summaryItems());
 }
 
@@ -765,6 +774,7 @@ function clearTimelineMarkerDrag() {
   stopTimelineMarkerAutoScroll(drag);
   if (drag.isDragging) {
     drag.line.classList.remove("dragging");
+    drag.handle.classList.remove("dragging");
     try {
       drag.handle.releasePointerCapture(drag.pointerId);
     } catch (_error) {
@@ -777,6 +787,7 @@ function clearTimelineMarkerDrag() {
 function beginTimelineMarkerDrag(event, drag) {
   drag.isDragging = true;
   drag.line.classList.add("dragging");
+  drag.handle.classList.add("dragging");
   drag.handle.setPointerCapture?.(event.pointerId);
   updateTimelineMarkerDrag(event);
 }
@@ -787,10 +798,12 @@ function startTimelineMarkerDrag(event) {
   const handle = timelineMarkerDragTarget(event.target);
   if (!handle) return;
 
-  const line = handle.closest(".timeline-current-line");
   const grid = handle.closest(".timeline-grid");
   const scroll = handle.closest(".timeline-scroll");
-  if (!(line instanceof HTMLElement) || !(grid instanceof HTMLElement) || !(scroll instanceof HTMLElement)) return;
+  if (!(grid instanceof HTMLElement) || !(scroll instanceof HTMLElement)) return;
+
+  const line = grid.querySelector(".timeline-current-line");
+  if (!(line instanceof HTMLElement)) return;
 
   const drag = {
     handle,

--- a/pc-management/app.js
+++ b/pc-management/app.js
@@ -541,8 +541,14 @@ function renderCurrentLine(grid, minYear, maxYear) {
   if (currentPosition !== null) {
     const currentLine = createElement("div", "timeline-current-line");
     currentLine.style.left = `${currentPosition}px`;
-    currentLine.innerHTML = '<button type="button" class="timeline-current-handle" data-action="drag-current-line" aria-label="現在ラインを動かす">✋</button>';
     grid.appendChild(currentLine);
+
+    const currentHandle = createElement("button", "timeline-current-handle", "✋");
+    currentHandle.type = "button";
+    currentHandle.dataset.action = "drag-current-line";
+    currentHandle.setAttribute("aria-label", "現在ラインを動かす");
+    currentHandle.style.left = `${currentPosition}px`;
+    grid.appendChild(currentHandle);
   }
 
   if (currentLabelPosition !== null) {
@@ -1098,7 +1104,10 @@ function timelineMonthFromClientX(clientX, scroll, minYear, maxYear) {
 function applyTimelineMarkerDragPosition(drag) {
   state.timelineMarkerMonth = timelineMonthFromClientX(drag.clientX, drag.scroll, drag.minYear, drag.maxYear);
   const position = currentLinePosition(drag.minYear, drag.maxYear);
-  if (position !== null) drag.line.style.left = `${position}px`;
+  if (position !== null) {
+    drag.line.style.left = `${position}px`;
+    drag.handle.style.left = `${position}px`;
+  }
   renderSummary();
 }
 
@@ -1198,6 +1207,7 @@ function clearTimelineMarkerDrag() {
   stopTimelineMarkerAutoScroll(drag);
   if (drag.isDragging) {
     drag.line.classList.remove("dragging");
+    drag.handle.classList.remove("dragging");
     try {
       drag.handle.releasePointerCapture(drag.pointerId);
     } catch (_error) {
@@ -1210,6 +1220,7 @@ function clearTimelineMarkerDrag() {
 function beginTimelineMarkerDrag(event, drag) {
   drag.isDragging = true;
   drag.line.classList.add("dragging");
+  drag.handle.classList.add("dragging");
   drag.handle.setPointerCapture?.(event.pointerId);
   updateTimelineMarkerDrag(event);
 }
@@ -1220,10 +1231,12 @@ function startTimelineMarkerDrag(event) {
   const handle = timelineMarkerDragTarget(event.target);
   if (!handle) return;
 
-  const line = handle.closest(".timeline-current-line");
   const grid = handle.closest(".timeline-grid");
   const scroll = handle.closest(".timeline-scroll");
-  if (!(line instanceof HTMLElement) || !(grid instanceof HTMLElement) || !(scroll instanceof HTMLElement)) return;
+  if (!(grid instanceof HTMLElement) || !(scroll instanceof HTMLElement)) return;
+
+  const line = grid.querySelector(".timeline-current-line");
+  if (!(line instanceof HTMLElement)) return;
 
   const drag = {
     handle,

--- a/style.css
+++ b/style.css
@@ -1214,8 +1214,9 @@ button {
 
 .timeline-current-handle {
   position: absolute;
-  top: -34px;
-  left: 50%;
+  top: 10px;
+  left: 0;
+  z-index: 10;
   display: grid;
   place-items: center;
   width: 34px;
@@ -1236,7 +1237,7 @@ button {
 }
 
 .timeline-current-handle:active,
-.timeline-current-line.dragging .timeline-current-handle {
+.timeline-current-handle.dragging {
   cursor: grabbing;
 }
 
@@ -2070,7 +2071,7 @@ button {
   }
 
   .timeline-current-handle {
-    top: -26px;
+    top: 1px;
     width: 28px;
     height: 28px;
     min-height: 28px;


### PR DESCRIPTION
## Summary
- move the timeline hand handle out of the current-line element and onto the timeline axis layer
- keep the handle aligned with the year labels while moving with the draggable marker
- update drag lookup so the handle works outside the line element

## Verification
- node --check js/list.js
- node --check pc-management/app.js
- git diff --check