### PR TITLE
PC管理の費用をメイン画面へ連動

### DIFF
--- a/form.html
+++ b/form.html
@@ -74,6 +74,8 @@
           </div>
           <div class="form-actions">
             <button id="submit-button" class="primary-button" type="submit">登録する</button>
+            <button id="pc-reflect-button" class="ghost-button" type="submit" hidden>PC管理を反映</button>
+            <button id="use-form-data-button" class="ghost-button" type="submit" hidden>入力フォームのデータを使う</button>
           </div>
           <button id="to-list-button" class="ghost-button" type="button">一覧に戻る</button>
         </form>

--- a/hidden.html
+++ b/hidden.html
@@ -34,6 +34,8 @@
       <article class="item-name-dialog-card">
         <h2 id="dialog-item-name"></h2>
         <p id="dialog-item-meta" class="dialog-item-meta"></p>
+        <p id="dialog-pc-prompt" class="dialog-item-meta" hidden></p>
+        <button id="dialog-pc-button" type="button" class="ghost-button" hidden>PC管理を表示</button>
         <div class="dialog-actions">
           <button id="dialog-edit-button" type="button" class="primary-button">編集</button>
           <button id="dialog-delete-button" type="button" class="danger-button">削除</button>

--- a/js/common.js
+++ b/js/common.js
@@ -540,6 +540,7 @@ function normalizeStoredItem(item) {
     assetReferenceItemId: String(item.assetReferenceItemId ?? item.assetReferenceItemCode ?? ""),
     assetReferenceItemCode: String(item.assetReferenceItemCode ?? ""),
     sourceType: item.sourceType ?? "",
+    pcManagementLinked: Boolean(item.pcManagementLinked),
     purchaseDate: item.purchaseDate ?? "",
     purchasePrice: Number(item.purchasePrice ?? 0),
     yearsOfUse: Number(item.yearsOfUse ?? 0),
@@ -612,6 +613,7 @@ export async function saveItem(uid, item) {
       category: item.category,
       assetReferenceItemId: item.assetReferenceItemId,
       assetReferenceItemCode: item.assetReferenceItemCode,
+      pcManagementLinked: Boolean(item.pcManagementLinked),
       purchaseDate: item.purchaseDate,
       purchasePrice: item.purchasePrice,
       yearsOfUse: item.yearsOfUse,
@@ -631,6 +633,7 @@ export async function saveItem(uid, item) {
     category: normalizeCategory(item.category),
     assetReferenceItemId: String(item.assetReferenceItemId ?? ""),
     assetReferenceItemCode: String(item.assetReferenceItemCode ?? ""),
+    pcManagementLinked: Boolean(item.pcManagementLinked),
     purchaseDate: item.purchaseDate,
     purchasePrice: item.purchasePrice,
     yearsOfUse: item.yearsOfUse,
@@ -657,11 +660,11 @@ export async function removeItem(uid, itemId) {
 
 export function validateItem(item) {
   if (!item.name.trim()) return "商品名を入力してください。";
-  if (!item.model.trim()) return "型番を入力してください。";
+  if (!item.pcManagementLinked && !item.model.trim()) return "型番を入力してください。";
   if (normalizeCategory(item.category) !== item.category) return "分類を選択してください。";
-  if (!item.purchaseDate) return "購入日を入力してください。";
-  if (!Number.isFinite(item.purchasePrice) || item.purchasePrice < 0) return "購入価格は0以上で入力してください。";
-  if (!Number.isFinite(item.yearsOfUse) || item.yearsOfUse <= 0) return "使用年数は1以上で入力してください。";
+  if (!item.pcManagementLinked && !item.purchaseDate) return "購入日を入力してください。";
+  if (!item.pcManagementLinked && (!Number.isFinite(item.purchasePrice) || item.purchasePrice < 0)) return "購入価格は0以上で入力してください。";
+  if (!item.pcManagementLinked && (!Number.isFinite(item.yearsOfUse) || item.yearsOfUse <= 0)) return "使用年数は1以上で入力してください。";
   if (item.endOfUseDate && calculateUsageMonths(item.purchaseDate, item.endOfUseDate) === 0) {
     return "使用終了日は購入日以降の日付を入力してください。";
   }

--- a/js/form.js
+++ b/js/form.js
@@ -20,6 +20,8 @@ import {
 import { loadItem, saveItem } from "./storage/durable-items/service.js";
 
 const EDITING_ITEM_ID_KEY = "monthlyApplianceBook.editingItemId";
+const PC_TOTAL_ITEM_NAME = "\u30d1\u30bd\u30b3\u30f3\u7dcf\u8cbb\u7528";
+const PC_TOTAL_CATEGORY = "information_device";
 const HIDDEN_TIMELINE_NOTICE_MESSAGE = "非表示でも使用年数が未達の場合は加算されます。";
 
 const authError = document.getElementById("auth-error");
@@ -28,6 +30,8 @@ const form = document.getElementById("item-form");
 const formPanel = document.getElementById("form-panel");
 const formError = document.getElementById("form-error");
 const submitButton = document.getElementById("submit-button");
+const pcReflectButton = document.getElementById("pc-reflect-button");
+const useFormDataButton = document.getElementById("use-form-data-button");
 
 const idInput = document.getElementById("item-id");
 const nameInput = document.getElementById("name");
@@ -113,9 +117,21 @@ const state = {
   editingId: new URLSearchParams(window.location.search).get("id") || sessionStorageGetItem(EDITING_ITEM_ID_KEY),
   assetReferenceData: null,
   excludeFromSummary: false,
+  pcManagementLinked: false,
   isDirty: false,
   isBusy: false,
 };
+
+function updatePcReflectButton() {
+  const canReflect =
+    !state.pcManagementLinked &&
+    nameInput.value.trim() === PC_TOTAL_ITEM_NAME &&
+    categoryInput.value === PC_TOTAL_CATEGORY;
+  if (pcReflectButton) pcReflectButton.hidden = !canReflect;
+  if (useFormDataButton) {
+    useFormDataButton.hidden = !(state.editingId && state.pcManagementLinked);
+  }
+}
 
 function updateAssetReferenceDisplay() {
   if (!unitPriceReference || !usefulLifeReference) return;
@@ -307,6 +323,8 @@ function fillForm(item) {
   endOfUseDateInput.value = item.endOfUseDate;
   hideFromTimelineInput.checked = Boolean(item.hideFromTimeline);
   state.excludeFromSummary = Boolean(item.excludeFromSummary);
+  state.pcManagementLinked = Boolean(item.pcManagementLinked);
+  updatePcReflectButton();
   updateEndedUseStyle();
   renderAdditionalCosts(item.additionalCosts);
   updateAssetReferenceDisplay();
@@ -340,6 +358,8 @@ additionalCostList.addEventListener("click", (event) => {
   updateCalculationResult();
 });
 
+nameInput.addEventListener("input", updatePcReflectButton);
+categoryInput.addEventListener("change", updatePcReflectButton);
 form.addEventListener("input", updateCalculationResult);
 form.addEventListener("change", updateCalculationResult);
 form.addEventListener("input", () => {
@@ -361,6 +381,8 @@ endOfUseDateInput.addEventListener("input", () => {
 form.addEventListener("submit", async (event) => {
   event.preventDefault();
   formError.textContent = "";
+  const usePcManagement = event.submitter === pcReflectButton;
+  const useFormData = event.submitter === useFormDataButton;
 
   const item = {
     id: idInput.value || createId(),
@@ -376,6 +398,7 @@ form.addEventListener("submit", async (event) => {
     endOfUseDate: endOfUseDateInput.value,
     hideFromTimeline: hideFromTimelineInput.checked,
     excludeFromSummary: state.excludeFromSummary,
+    pcManagementLinked: usePcManagement || (!useFormData && state.pcManagementLinked),
     additionalCosts: collectAdditionalCosts(),
   };
   const validation = validateItem(item);
@@ -419,6 +442,8 @@ async function initializeForm(user) {
   populateAssetReferenceSelect();
 
   if (!state.editingId) {
+    state.pcManagementLinked = false;
+    updatePcReflectButton();
     sessionStorageRemoveItem(EDITING_ITEM_ID_KEY);
     submitButton.textContent = "登録する";
     updateEndedUseStyle();

--- a/js/list.js
+++ b/js/list.js
@@ -15,6 +15,7 @@ import { isLocalMode } from "./platform/local-db.js";
 import { onAuthChanged, logout, registerServiceWorker } from "./services/auth.js";
 import { shouldExcludeUnderusedMonthlyCost } from "./services/app-settings.js";
 import { loadItems, removeItem, saveItem } from "./storage/durable-items/service.js";
+import { calculatePcSummaryAt, loadPcSummaryItems } from "./services/pc-summary.js";
 
 const EDITING_ITEM_ID_KEY = "monthlyApplianceBook.editingItemId";
 
@@ -37,6 +38,8 @@ const summaryItemCount = document.getElementById("summary-item-count");
 const itemNameDialog = document.getElementById("item-name-dialog");
 const dialogItemName = document.getElementById("dialog-item-name");
 const dialogItemMeta = document.getElementById("dialog-item-meta");
+const dialogPcPrompt = document.getElementById("dialog-pc-prompt");
+const dialogPcButton = document.getElementById("dialog-pc-button");
 const dialogEditButton = document.getElementById("dialog-edit-button");
 const dialogDeleteButton = document.getElementById("dialog-delete-button");
 const dialogCloseButton = document.getElementById("dialog-close-button");
@@ -59,6 +62,10 @@ const state = {
   uid: null,
   items: [],
   summaryItems: [],
+  pcItems: [],
+  pcCurrentMonthlyCost: 0,
+  pcMonthlyCost: 0,
+  pcPurchaseTotal: 0,
   selectedCategories: new Set(CATEGORY_OPTIONS.map((category) => category.value)),
   selectedItemId: null,
   resizeTimer: null,
@@ -123,7 +130,12 @@ function formatYearMonthFromIndex(monthIndex) {
   return `${year}/${String(month).padStart(2, "0")}`;
 }
 
+function isPcManagementLinkedItem(item) {
+  return Boolean(item?.pcManagementLinked);
+}
+
 function itemStartMonth(item) {
+  if (isPcManagementLinkedItem(item)) return TIMELINE_MIN_YEAR * 12;
   const purchaseDate = parseDate(item.purchaseDate);
   return purchaseDate ? toMonthPosition(purchaseDate) : TIMELINE_MIN_YEAR * 12;
 }
@@ -133,6 +145,7 @@ function currentMonthIndex() {
 }
 
 function itemPlannedEndMonth(item) {
+  if (isPcManagementLinkedItem(item)) return TIMELINE_MAX_YEAR * 12;
   const purchaseDate = parseDate(item.purchaseDate);
   const yearsOfUse = Math.max(Number(item.yearsOfUse) || 1, 1);
   if (!purchaseDate) {
@@ -169,6 +182,7 @@ function itemTimelineEndMonth(item) {
 }
 
 function itemEndLabel(item, endMonth) {
+  if (isPcManagementLinkedItem(item)) return "";
   if (item.endOfUseDate) {
     return `${formatYearMonthFromIndex(endMonth)} (使用終了)`;
   }
@@ -234,11 +248,33 @@ function lifecycleStatus(item) {
   return "normal";
 }
 
+function updatePcSummaryForMonth(monthPosition = timelineMarkerMonth()) {
+  const summary = calculatePcSummaryAt(state.pcItems, monthPosition);
+  state.pcMonthlyCost = summary.monthlyCost;
+  state.pcPurchaseTotal = summary.purchaseTotal;
+}
+
+function isTimelineMarkerAtCurrentMonth() {
+  return Math.floor(timelineMarkerMonth()) === currentMonthIndex();
+}
+
+function updatePcLinkedCostDisplays() {
+  itemList.querySelectorAll(".pc-linked-current-cost").forEach((element) => {
+    element.textContent = `${formatCurrency(state.pcCurrentMonthlyCost)} /\u6708`;
+  });
+  itemList.querySelectorAll(".pc-linked-selected-cost").forEach((element) => {
+    element.textContent = `\u9078\u629e\u6708 ${formatCurrency(state.pcMonthlyCost)} /\u6708`;
+    element.hidden = isTimelineMarkerAtCurrentMonth();
+  });
+}
+
 function timelineMonthlyCost(item) {
+  if (isPcManagementLinkedItem(item)) return state.pcMonthlyCost;
   return isPcManagementItem(item) ? calculateMonthlyCost(item) : calculateMonthlyCostWithAdditionalCosts(item);
 }
 
 function itemSummaryMonthlyCost(item, monthPosition = timelineMarkerMonth()) {
+  if (isPcManagementLinkedItem(item)) return state.pcMonthlyCost;
   return itemPlannedEndMonth(item) < monthPosition ? 0 : timelineMonthlyCost(item);
 }
 
@@ -247,6 +283,7 @@ function displayedMonthlyCost(item) {
 }
 
 function totalPurchaseCost(item) {
+  if (isPcManagementLinkedItem(item)) return state.pcPurchaseTotal;
   return Number(item.purchasePrice || 0) + calculateAdditionalCostTotal(item);
 }
 
@@ -525,17 +562,18 @@ function renderTimeline(items) {
 
   const rows = createElement("div", "timeline-rows");
   for (const item of sortedItems) {
-    const startMonth = itemStartMonth(item);
-    const endMonth = itemEndMonth(item);
+    const isLinkedToPcManagement = isPcManagementLinkedItem(item);
+    const startMonth = isLinkedToPcManagement ? minMonth : itemStartMonth(item);
+    const endMonth = isLinkedToPcManagement ? maxYear * 12 : itemEndMonth(item);
     const unusedPeriodEndMonth = itemUnusedPeriodEndMonth(item);
-    const plannedEndMonth = itemPlannedEndMonth(item);
+    const plannedEndMonth = isLinkedToPcManagement ? maxYear * 12 : itemPlannedEndMonth(item);
     const status = lifecycleStatus(item);
     const left = labelWidth + ((startMonth - minMonth) / 12) * yearWidth;
     const width = Math.max(((endMonth - startMonth) / 12) * yearWidth, timelineLayout().isCompact ? 32 : 84);
     const unusedPeriodLeft = labelWidth + ((endMonth - minMonth) / 12) * yearWidth;
     const unusedPeriodWidth = ((unusedPeriodEndMonth - endMonth) / 12) * yearWidth;
     const overuseStartPercent = ((plannedEndMonth - startMonth) / Math.max(endMonth - startMonth, 1)) * 100;
-    const isOverused = itemActualEndMonth(item) > plannedEndMonth;
+    const isOverused = !isLinkedToPcManagement && itemActualEndMonth(item) > plannedEndMonth;
     const isSelected = item.id === state.selectedItemId;
 
     const row = createElement("div", "timeline-row");
@@ -555,6 +593,9 @@ function renderTimeline(items) {
     band.setAttribute("aria-label", `${item.name}の詳細を表示`);
     band.style.left = `${left}px`;
     band.style.width = `${width}px`;
+    if (isLinkedToPcManagement) {
+      band.classList.add("pc-management-linked");
+    }
     if (isOverused) {
       band.style.setProperty("--overuse-start", `${Math.min(Math.max(overuseStartPercent, 0), 100)}%`);
       band.classList.add("is-overused");
@@ -563,6 +604,22 @@ function renderTimeline(items) {
     const purchaseText = createElement("span", "band-name", item.name || "商品名未入力");
     const costText = createElement("span", "band-cost", `${formatCurrency(timelineMonthlyCost(item))} /月`);
     band.append(purchaseText, costText);
+
+    if (isLinkedToPcManagement) {
+      const linkedLabel = createElement("span", "pc-linked-cost-label");
+      const selectedCost = createElement(
+        "span",
+        "pc-linked-selected-cost",
+        `\u9078\u629e\u6708 ${formatCurrency(state.pcMonthlyCost)} /\u6708`
+      );
+      selectedCost.hidden = isTimelineMarkerAtCurrentMonth();
+      linkedLabel.append(
+        createElement("span", "pc-linked-reflection", "PC\u7ba1\u7406\u3092\u53cd\u6620"),
+        createElement("span", "pc-linked-current-cost", `${formatCurrency(state.pcCurrentMonthlyCost)} /\u6708`),
+        selectedCost
+      );
+      row.appendChild(linkedLabel);
+    }
 
     if (isOverused) {
       const plannedCostLabel = costText.cloneNode(true);
@@ -604,6 +661,17 @@ function renderTimeline(items) {
   renderAxis(grid, minYear, maxYear, "timeline-axis-bottom");
   scroll.appendChild(grid);
   itemList.appendChild(scroll);
+
+  const updateLinkedLabelPosition = () => {
+    const visibleLeft = scroll.scrollLeft + labelWidth;
+    const visibleRight = scroll.scrollLeft + scroll.clientWidth;
+    const visibleCenter = (visibleLeft + visibleRight) / 2;
+    grid.querySelectorAll(".pc-linked-cost-label").forEach((label) => {
+      label.style.left = `${visibleCenter}px`;
+    });
+  };
+  scroll.addEventListener("scroll", updateLinkedLabelPosition, { passive: true });
+  requestAnimationFrame(updateLinkedLabelPosition);
   centerCurrentLine(scroll, minYear, maxYear);
 }
 
@@ -621,14 +689,29 @@ function selectItem(itemId) {
 function openItemNameDialog(item) {
   if (!item || !itemNameDialog) return;
   dialogItemName.textContent = item.name || "商品名未入力";
-  dialogItemMeta.textContent = `購入金額${formatCurrency(Number(item.purchasePrice || 0))} / ${formatCurrency(
-    timelineMonthlyCost(item)
-  )} /月`;
+  const isLinked = isPcManagementLinkedItem(item);
+  dialogItemMeta.textContent = isLinked
+    ? `PC\u7ba1\u7406\u3092\u53cd\u6620 ${formatCurrency(state.pcCurrentMonthlyCost)} /\u6708`
+    : `\u8cfc\u5165\u91d1\u984d${formatCurrency(Number(item.purchasePrice || 0))} / ${formatCurrency(
+      timelineMonthlyCost(item)
+    )} /\u6708`;
+  if (dialogPcPrompt && dialogPcButton) {
+    dialogPcPrompt.hidden = !isLinked;
+    dialogPcButton.hidden = !isLinked;
+    dialogPcPrompt.textContent = "PC\u7ba1\u7406\u3092\u8868\u793a\u3057\u307e\u3059\u304b\uff1f";
+    dialogPcButton.textContent = "PC\u7ba1\u7406\u3092\u8868\u793a";
+  }
   itemNameDialog.showModal();
 }
 
 async function refreshList() {
-  const loadedItems = await loadItems(state.uid);
+  const [loadedItems, pcItems] = await Promise.all([
+    loadItems(state.uid),
+    loadPcSummaryItems(state.uid),
+  ]);
+  state.pcItems = pcItems;
+  state.pcCurrentMonthlyCost = calculatePcSummaryAt(pcItems, currentMonthIndex()).monthlyCost;
+  updatePcSummaryForMonth();
   state.summaryItems = loadedItems.filter((item) => !isPcManagementItem(item));
   state.items =
     TIMELINE_MODE === "hidden"
@@ -705,6 +788,7 @@ function timelineMonthFromClientX(clientX, scroll, minYear, maxYear) {
 
 function applyTimelineMarkerDragPosition(drag) {
   state.timelineMarkerMonth = timelineMonthFromClientX(drag.clientX, drag.scroll, drag.minYear, drag.maxYear);
+  updatePcSummaryForMonth();
   const position = currentLinePosition(drag.minYear, drag.maxYear);
   if (position !== null) {
     drag.line.style.left = `${position}px`;
@@ -713,6 +797,7 @@ function applyTimelineMarkerDragPosition(drag) {
     });
   }
   summarizeItems(summaryItems());
+  updatePcLinkedCostDisplays();
 }
 
 function timelineMarkerAutoScrollSpeed(drag) {
@@ -1094,6 +1179,12 @@ itemList.addEventListener("pointerup", cancelSummaryToggleLongPress);
 itemList.addEventListener("pointercancel", cancelSummaryToggleLongPress);
 itemList.addEventListener("pointerleave", cancelSummaryToggleLongPress);
 itemList.addEventListener("pointermove", cancelMovedSummaryToggleLongPress);
+
+dialogPcButton?.addEventListener("click", () => {
+  const item = selectedItem();
+  if (!isPcManagementLinkedItem(item)) return;
+  window.location.href = "pc-management/index.html";
+});
 
 dialogEditButton.addEventListener("click", () => {
   const item = selectedItem();

--- a/js/services/pc-summary.js
+++ b/js/services/pc-summary.js
@@ -1,0 +1,67 @@
+import { getItems as getPcItems } from "../storage/pc-items/index.js";
+import { shouldExcludeUnderusedMonthlyCost } from "./app-settings.js";
+
+function parseDate(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  const match = text.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
+  if (match) {
+    const [, year, month, day] = match;
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  const date = new Date(`${text}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function monthIndex(date) {
+  return date.getFullYear() * 12 + date.getMonth();
+}
+
+function plannedEndMonth(item) {
+  const start = parseDate(item.purchaseDate);
+  const years = Math.max(Number(item.yearsOfUse) || 1, 1);
+  return start ? monthIndex(start) + years * 12 : null;
+}
+
+function monthlyCost(item) {
+  const price = Number(item.purchasePrice ?? item.price ?? 0);
+  const years = Number(item.yearsOfUse ?? 0);
+  if (!Number.isFinite(price) || !Number.isFinite(years) || years <= 0) return 0;
+  return price / (years * 12);
+}
+
+function isActiveAtMonth(item, targetMonth) {
+  if (item.excludeFromSummary) return false;
+  const start = parseDate(item.purchaseDate);
+  const plannedEnd = plannedEndMonth(item);
+  if (!start || plannedEnd === null) return false;
+
+  const startMonth = monthIndex(start);
+  const ended = parseDate(item.endOfUseDate);
+  let activeEnd = plannedEnd;
+  if (ended) {
+    const actualEnd = Math.max(startMonth, monthIndex(ended));
+    const isUnderused = actualEnd < plannedEnd;
+    activeEnd = isUnderused && !shouldExcludeUnderusedMonthlyCost()
+      ? plannedEnd
+      : Math.min(actualEnd, plannedEnd);
+  }
+  return startMonth <= targetMonth && targetMonth <= activeEnd;
+}
+
+export async function loadPcSummaryItems(uid) {
+  return getPcItems(uid);
+}
+
+export function calculatePcSummaryAt(items, monthPosition) {
+  const targetMonth = Math.floor(Number(monthPosition));
+  if (!Number.isFinite(targetMonth)) return { monthlyCost: 0, purchaseTotal: 0 };
+
+  return items.reduce((summary, item) => {
+    if (!isActiveAtMonth(item, targetMonth)) return summary;
+    summary.monthlyCost += Math.round(monthlyCost(item));
+    summary.purchaseTotal += Number(item.purchasePrice ?? item.price ?? 0) || 0;
+    return summary;
+  }, { monthlyCost: 0, purchaseTotal: 0 });
+}

--- a/js/storage/durable-items/firestore.js
+++ b/js/storage/durable-items/firestore.js
@@ -48,6 +48,7 @@ export async function saveItem(uid, item, options = {}) {
     category: item.category,
     assetReferenceItemId: item.assetReferenceItemId,
     assetReferenceItemCode: item.assetReferenceItemCode,
+    pcManagementLinked: Boolean(item.pcManagementLinked),
     purchaseDate: item.purchaseDate,
     purchasePrice: item.purchasePrice,
     yearsOfUse: item.yearsOfUse,

--- a/js/storage/durable-items/service.js
+++ b/js/storage/durable-items/service.js
@@ -33,6 +33,7 @@ function normalizeStoredItem(item) {
     assetReferenceItemId: String(item.assetReferenceItemId ?? item.assetReferenceItemCode ?? ""),
     assetReferenceItemCode: String(item.assetReferenceItemCode ?? ""),
     sourceType: item.sourceType ?? "",
+    pcManagementLinked: Boolean(item.pcManagementLinked),
     purchaseDate: item.purchaseDate ?? "",
     purchasePrice: Number(item.purchasePrice ?? 0),
     yearsOfUse: Number(item.yearsOfUse ?? 0),

--- a/list.html
+++ b/list.html
@@ -96,6 +96,8 @@
       <article class="item-name-dialog-card">
         <h2 id="dialog-item-name"></h2>
         <p id="dialog-item-meta" class="dialog-item-meta"></p>
+        <p id="dialog-pc-prompt" class="dialog-item-meta" hidden></p>
+        <button id="dialog-pc-button" type="button" class="ghost-button" hidden>PC管理を表示</button>
         <div class="dialog-actions">
           <button id="dialog-edit-button" type="button" class="primary-button">編集</button>
           <button id="dialog-delete-button" type="button" class="danger-button">削除</button>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v102";
+const CACHE_NAME = "durable-goods-pwa-v103";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",
@@ -20,6 +20,7 @@ const APP_SHELL = [
   "js/services/app-settings.js",
   "js/services/asset-reference.js",
   "js/services/auth.js",
+  "js/services/pc-summary.js",
   "js/storage/durable-items/firestore.js",
   "js/storage/durable-items/index.js",
   "js/storage/durable-items/local.js",

--- a/style.css
+++ b/style.css
@@ -209,6 +209,17 @@ textarea:focus {
   font-size: 0.9rem;
 }
 
+#pc-reflect-button[hidden],
+#use-form-data-button[hidden],
+#dialog-pc-prompt[hidden],
+#dialog-pc-button[hidden] {
+  display: none;
+}
+
+#dialog-pc-button {
+  width: 100%;
+}
+
 .form-actions {
   display: grid;
   grid-template-columns: 1fr;
@@ -1435,6 +1446,42 @@ button {
   display: none;
 }
 
+.lifecycle-band.pc-management-linked .band-name,
+.lifecycle-band.pc-management-linked .band-cost {
+  display: none;
+}
+
+.pc-linked-cost-label {
+  position: absolute;
+  top: 12px;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 48px;
+  transform: translateX(-50%);
+  color: #f8fafc;
+  font-size: 0.86rem;
+  font-weight: 800;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.pc-linked-reflection {
+  color: #b8c5d1;
+  font-size: 0.78rem;
+}
+
+.pc-linked-selected-cost {
+  padding-left: 8px;
+  border-left: 1px solid rgba(248, 250, 252, 0.32);
+}
+
+.pc-linked-selected-cost[hidden] {
+  display: none;
+}
+
 .timeline-end-label {
   position: absolute;
   top: 27px;
@@ -2175,7 +2222,8 @@ button {
   .band-cost,
   .timeline-end-label,
   .timeline-planned-cost-label,
-  .timeline-zero-cost-label {
+  .timeline-zero-cost-label,
+  .pc-linked-cost-label {
     display: none;
   }
 
@@ -2235,5 +2283,15 @@ button {
 
   .dialog-actions {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .band-cost,
+  .timeline-end-label,
+  .timeline-planned-cost-label,
+  .timeline-zero-cost-label,
+  .pc-linked-cost-label {
+    display: none;
   }
 }


### PR DESCRIPTION
PC管理の月額・購入額をパソコン総費用へ連動し、タイムライン選択年月に応じて集計を更新します。登録・解除、詳細ダイアログからのPC管理遷移、スマホでの月額表示抑制も含みます。\n\n確認済み:\n- 対象JavaScriptの node --check\n- service-worker.js の node --check\n- git diff --check