### PR TITLE
Show PC reflection label on mobile

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "durable-goods-pwa-v103";
+const CACHE_NAME = "durable-goods-pwa-v104";
 const BASE_URL = new URL(self.registration.scope);
 const APP_SHELL = [
   "./",

--- a/style.css
+++ b/style.css
@@ -2222,8 +2222,18 @@ button {
   .band-cost,
   .timeline-end-label,
   .timeline-planned-cost-label,
-  .timeline-zero-cost-label,
+  .timeline-zero-cost-label {
+    display: none;
+  }
+
   .pc-linked-cost-label {
+    top: 7px;
+    display: flex;
+    height: 24px;
+  }
+
+  .pc-linked-current-cost,
+  .pc-linked-selected-cost {
     display: none;
   }
 
@@ -2286,7 +2296,7 @@ button {
   }
 }
 
-@media (hover: none) and (pointer: coarse) {
+@media (hover: none) and (pointer: coarse) and (min-width: 641px) {
   .band-cost,
   .timeline-end-label,
   .timeline-planned-cost-label,


### PR DESCRIPTION
## Summary
- show the PC management reflection label in the visible center of the mobile timeline band
- keep PC cost details hidden on mobile
- bump the PWA cache version

## Verification
- node --check service-worker.js
- git diff --check